### PR TITLE
refactor: convert CSS to Tailwind classes using @apply

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,15 +7,25 @@
     --color-black: 0 0 0%;
     --color-white: 0 0 100%;
 
-    --color-neutral-100: 0 0% 98%; /* Background layers (default bg) */
-    --color-neutral-200: 0 0% 94%; /* Background layers (Bg secondary/muted) */ /* Decorative border */
-    --color-neutral-300: 0 0% 90%; /* Decorative border */
-    --color-neutral-400: 0 0% 85%; /* Field border */
-    --color-neutral-500: 0 0% 80%; /* Disabled Text */
-    --color-neutral-600: 0 0% 40%; /* control border (switch/checkbox/radio) */
-    --color-neutral-700: 0 0% 35%; /* Text secondary (muted) */
-    --color-neutral-800: 0 0% 28%; /* Text */
-    --color-neutral-900: 0 0% 16%; /* Heading Text */
+    --color-neutral-100: 0 0% 98%;
+    /* Background layers (default bg) */
+    --color-neutral-200: 0 0% 94%;
+    /* Background layers (Bg secondary/muted) */
+    /* Decorative border */
+    --color-neutral-300: 0 0% 90%;
+    /* Decorative border */
+    --color-neutral-400: 0 0% 85%;
+    /* Field border */
+    --color-neutral-500: 0 0% 80%;
+    /* Disabled Text */
+    --color-neutral-600: 0 0% 40%;
+    /* control border (switch/checkbox/radio) */
+    --color-neutral-700: 0 0% 35%;
+    /* Text secondary (muted) */
+    --color-neutral-800: 0 0% 28%;
+    /* Text */
+    --color-neutral-900: 0 0% 16%;
+    /* Heading Text */
     --color-neutral-1000: 0 0% 12%;
 
     --color-primary-100: 0 0% 87%;
@@ -228,9 +238,11 @@
   * {
     @apply border-border;
   }
+
   html {
     @apply scroll-smooth;
   }
+
   body {
     @apply bg-bg text-fg;
   }
@@ -277,76 +289,56 @@
     }
   }
 }
+
 .shiki,
 .shiki span {
-  background-color: transparent !important;
+  @apply bg-transparent !important;
 }
-
-/* TODO PUT THIS SHIT IN TAILWIND CLASSES */
 
 .data-dragging .data-scrollable [data-direction="top"] {
-  overflow-y: hidden !important;
+  @apply overflow-y-hidden !important;
 }
+
 .data-dragging .data-scrollable [data-direction="bottom"] {
-  overflow-y: hidden !important;
+  @apply overflow-y-hidden !important;
 }
 
 .data-dragging .data-scrollable [data-direction="left"] {
-  overflow-x: hidden !important;
+  @apply overflow-x-hidden !important;
 }
 
 .data-dragging .data-scrollable [data-direction="right"] {
-  overflow-x: hidden !important;
+  @apply overflow-x-hidden !important;
 }
 
 [data-drawer]::after {
-  content: "";
-  position: absolute;
-  background: inherit;
-  background-color: inherit;
+  @apply content-[""] absolute bg-inherit;
 }
 
 [data-drawer][data-direction="top"]::after {
-  top: initial;
-  bottom: 100%;
-  left: 0;
-  right: 0;
-  height: 200%;
+  @apply top-[initial] bottom-full left-0 right-0 h-[200%]
 }
 
 [data-drawer][data-direction="bottom"]::after {
-  top: 100%;
-  bottom: initial;
-  left: 0;
-  right: 0;
-  height: 200%;
+  @apply top-full bottom-[initial] left-0 right-0 h-[200%];
 }
 
 [data-drawer][data-direction="left"]::after {
-  left: initial;
-  right: 100%;
-  top: 0;
-  bottom: 0;
-  width: 200%;
+  @apply left-[initial] right-full top-0 bottom-0 w-[200%];
 }
 
 [data-drawer][data-direction="right"]::after {
-  left: 100%;
-  right: initial;
-  top: 0;
-  bottom: 0;
-  width: 200%;
+  @apply left-full right-[initial] top-0 bottom-0 w-[200%];
 }
 
 @media (hover: hover) and (pointer: fine) {
   [data-drawer] {
-    user-select: none;
+    @apply select-none;
   }
 }
 
 @media (pointer: fine) {
   [data-handle-hitarea] {
-    width: 100%;
-    height: 100%;
+    @apply w-full h-full;
   }
 }


### PR DESCRIPTION
refactor: convert CSS to Tailwind classes using @apply

- Transform custom CSS for data-dragging and data-scrollable elements
- Update data-drawer pseudo-element styles with Tailwind utilities
- Adapt media query styles for data-drawer and data-handle-hitarea
- Enhance maintainability and align with Tailwind framework