### PR TITLE
fix: update live style logic

### DIFF
--- a/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/page.tsx
+++ b/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/page.tsx
@@ -36,7 +36,7 @@ export default async function BlockViewPage({
   }
 
   return (
-    <BlockProviders style={style}>
+    <BlockProviders style={style} styleSlug={`${username}/${styleName}`}>
       <BlockViewer name={blockName} />
     </BlockProviders>
   );

--- a/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
+++ b/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
@@ -45,7 +45,7 @@ export const BlockProviders = ({
         <StyleProvider
           style={style}
           mode={activeMode}
-          className="min-h-screen flex items-center justify-center"
+          className="flex min-h-screen items-center justify-center"
         >
           {children}
         </StyleProvider>

--- a/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
+++ b/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
@@ -42,7 +42,11 @@ export const BlockProviders = ({
         className="text-fg"
       />
       <PortalProvider getContainer={() => overlayContainerRef.current}>
-        <StyleProvider style={style} mode={activeMode} className="min-h-screen">
+        <StyleProvider
+          style={style}
+          mode={activeMode}
+          className="min-h-screen flex items-center justify-center"
+        >
           {children}
         </StyleProvider>
       </PortalProvider>

--- a/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
+++ b/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
@@ -13,16 +13,18 @@ import { usePreferences } from "@/modules/styles/atoms/preferences-atom";
 
 export const BlockProviders = ({
   style: styleProp,
+  styleSlug,
   children,
 }: {
   style: StyleDefinition & { id?: string };
+  styleSlug: string;
   children: React.ReactNode;
 }) => {
   const overlayContainerRef = React.useRef(null);
 
   const { activeMode } = usePreferences();
   const isMounted = useMounted();
-  const { liveStyle } = useLiveStyleConsumer(styleProp.id || "default");
+  const { liveStyle } = useLiveStyleConsumer(styleSlug);
 
   const style = React.useMemo(() => {
     return liveStyle ?? styleProp;


### PR DESCRIPTION
Fix live style preview to use `username/styleName` slug instead of `styleId`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e86d3dd-c0c1-4139-95a0-c6763aaf88cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e86d3dd-c0c1-4139-95a0-c6763aaf88cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

