### PR TITLE
fix: use resolved theme for style cards

### DIFF
--- a/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/page.tsx
+++ b/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/page.tsx
@@ -18,10 +18,13 @@ import { BlockProviders } from "./providers";
 
 export default async function BlockViewPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ username: string; styleName: string; blockName: string }>;
+  searchParams: Promise<{ useActiveMode?: string }>;
 }) {
   const { username, styleName, blockName } = await params;
+  const { useActiveMode } = await searchParams;
 
   const queryClient = getQueryClient();
   const style = await queryClient.fetchQuery(
@@ -36,7 +39,11 @@ export default async function BlockViewPage({
   }
 
   return (
-    <BlockProviders style={style} styleSlug={`${username}/${styleName}`}>
+    <BlockProviders
+      style={style}
+      styleSlug={`${username}/${styleName}`}
+      useActiveMode={useActiveMode === "true"}
+    >
       <BlockViewer name={blockName} />
     </BlockProviders>
   );

--- a/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
+++ b/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React from "react";
-import { UNSAFE_PortalProvider as PortalProvider } from "react-aria";
 import { useTheme } from "next-themes";
+import { UNSAFE_PortalProvider as PortalProvider } from "react-aria";
 
 import { StyleProvider } from "@dotui/ui";
 import { DisableSuspense } from "@dotui/ui/helpers/create-dynamic-component";

--- a/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
+++ b/www/app/(block-view)/block-view/[username]/[styleName]/[blockName]/providers.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { UNSAFE_PortalProvider as PortalProvider } from "react-aria";
+import { useTheme } from "next-themes";
 
 import { StyleProvider } from "@dotui/ui";
 import { DisableSuspense } from "@dotui/ui/helpers/create-dynamic-component";
@@ -15,20 +16,27 @@ export const BlockProviders = ({
   style: styleProp,
   styleSlug,
   children,
+  useActiveMode = false,
 }: {
   style: StyleDefinition & { id?: string };
   styleSlug: string;
   children: React.ReactNode;
+  useActiveMode?: boolean;
 }) => {
   const overlayContainerRef = React.useRef(null);
 
   const { activeMode } = usePreferences();
   const isMounted = useMounted();
   const { liveStyle } = useLiveStyleConsumer(styleSlug);
+  const { resolvedTheme } = useTheme();
 
   const style = React.useMemo(() => {
     return liveStyle ?? styleProp;
   }, [liveStyle, styleProp]);
+
+  const mode = useActiveMode
+    ? activeMode
+    : (resolvedTheme as "light" | "dark" | undefined);
 
   if (!isMounted || !style) return null;
 
@@ -37,14 +45,14 @@ export const BlockProviders = ({
       <StyleProvider
         ref={overlayContainerRef}
         style={style}
-        mode={activeMode}
+        mode={mode}
         unstyled
         className="text-fg"
       />
       <PortalProvider getContainer={() => overlayContainerRef.current}>
         <StyleProvider
           style={style}
-          mode={activeMode}
+          mode={mode}
           className="flex min-h-screen items-center justify-center"
         >
           {children}

--- a/www/components/preview.tsx
+++ b/www/components/preview.tsx
@@ -210,7 +210,7 @@ export function PreviewContent({
           <Tooltip content="Open in new tab" delay={0}>
             <Button
               aria-label="Open in new tab"
-              href={`/block-view/${username}/${styleName}/${currentBlockName}`}
+              href={`/block-view/${username}/${styleName}/${currentBlockName}?useActiveMode=true`}
               target="_blank"
               variant="quiet"
               shape="square"
@@ -240,7 +240,7 @@ export function PreviewContent({
         )}
       >
         <iframe
-          src={`/block-view/${username}/${styleName}/${currentBlockName}`}
+          src={`/block-view/${username}/${styleName}/${currentBlockName}?useActiveMode=false`}
           onLoad={() => setLoading(false)}
           className={cn(
             "rounded-{inherit] size-full",

--- a/www/modules/styles/components/style-card.tsx
+++ b/www/modules/styles/components/style-card.tsx
@@ -100,7 +100,7 @@ export function StyleCard({
             >
               <iframe
                 onLoad={() => setLoading(false)}
-                src={`/block-view/${style.user.username}/${style.name}/blocks-showcase`}
+                src={`/block-view/${style.user.username}/${style.name}/blocks-showcase?useActiveMode=false`}
                 className={cn(
                   "h-[1200px] min-w-[1400px] scale-50",
                   isLoading && "opacity-0",

--- a/www/scripts/capture-showcase-blocks.ts
+++ b/www/scripts/capture-showcase-blocks.ts
@@ -29,7 +29,7 @@ async function captureScreenshots() {
   });
 
   for (const style of featuredStyles) {
-    const pageUrl = `http://localhost:3000/block-view/${style.user.username}/${style.name}/blocks-showcase`;
+    const pageUrl = `http://localhost:3000/block-view/${style.user.username}/${style.name}/blocks-showcase?useActiveMode=false`;
 
     const page = await browser.newPage();
     await page.goto(pageUrl, {


### PR DESCRIPTION
Update block-view page to use `resolvedTheme` by default for style previews, with an opt-in search parameter for `activeMode`.

The `style-card` previews were showing the user's `activeMode` (from `usePreferences`), which could differ from the `resolvedTheme` (from `next-themes`) used elsewhere. This change ensures that embedded style previews consistently reflect the `resolvedTheme` for accurate representation, while providing an option to view with `activeMode` when navigating directly to the block-view page.

---
<a href="https://cursor.com/background-agent?bcId=bc-fef07c0a-c21c-4e07-bfd5-23f525e512dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fef07c0a-c21c-4e07-bfd5-23f525e512dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

