### PR TITLE
Add legal pages with markdown and prose

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.1.10
+      '@tailwindcss/typography':
+        specifier: ^0.5.16
+        version: 0.5.16(tailwindcss@4.1.10)
       '@types/estree':
         specifier: ^1.0.6
         version: 1.0.8
@@ -3468,6 +3471,11 @@ packages:
   '@tailwindcss/postcss@4.1.10':
     resolution: {integrity: sha512-B+7r7ABZbkXJwpvt2VMnS6ujcDoR2OOcFaqrLIo1xbcdxje4Vf+VgJdBzNNbrAjBj/rLZ66/tlQ1knIGNLKOBQ==}
 
+  '@tailwindcss/typography@0.5.16':
+    resolution: {integrity: sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tanstack/query-core@5.81.2':
     resolution: {integrity: sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==}
 
@@ -5701,9 +5709,15 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -6401,6 +6415,10 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.0:
     resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
@@ -10605,6 +10623,14 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.10
 
+  '@tailwindcss/typography@0.5.16(tailwindcss@4.1.10)':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.10
+
   '@tanstack/query-core@5.81.2': {}
 
   '@tanstack/react-query@5.81.2(react@19.0.0)':
@@ -13192,7 +13218,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.castarray@4.4.0: {}
+
   lodash.get@4.4.2: {}
+
+  lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
 
@@ -14183,6 +14213,11 @@ snapshots:
   pkce-challenge@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.0:
     dependencies:

--- a/www/app/(legal)/layout.tsx
+++ b/www/app/(legal)/layout.tsx
@@ -1,0 +1,13 @@
+export default function LegalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="container py-12">
+      <article className="prose prose-neutral max-w-none dark:prose-invert">
+        {children}
+      </article>
+    </div>
+  );
+}

--- a/www/app/(legal)/privacy-policy/page.mdx
+++ b/www/app/(legal)/privacy-policy/page.mdx
@@ -1,0 +1,64 @@
+export const metadata = {
+	title: "Privacy Policy",
+};
+
+# Privacy Policy
+
+_Last updated: 2025-08-14_
+
+This Privacy Policy explains how we collect, use, and share information when you use dotUI ("we", "us", or "our"). By using our website and services, you agree to the terms described below.
+
+## Information we collect
+
+- **Usage data**: Pages visited, interactions, referring URLs, approximate location, device, and browser information.
+- **Account data**: If you create an account or submit forms, we may collect your name, email, and any details you provide.
+- **Cookies and similar technologies**: We use cookies and local storage to remember preferences and improve your experience.
+
+## How we use information
+
+- **Provide and improve the service**: Operate, maintain, and enhance features and content.
+- **Analytics and measurement**: Understand how the site is used to make improvements.
+- **Communication**: Send service-related updates, announcements, and respond to inquiries.
+- **Security**: Detect, prevent, and respond to abuse, fraud, or security incidents.
+
+## Legal bases (EEA/UK only)
+
+Where applicable law requires, we process personal data based on: (i) your consent; (ii) performance of a contract; (iii) legitimate interests; or (iv) legal obligations.
+
+## Cookies
+
+You can control cookies through your browser settings. Disabling cookies may impact functionality.
+
+## Data retention
+
+We retain information for as long as necessary to fulfill the purposes outlined in this policy unless a longer retention period is required or permitted by law.
+
+## Data sharing
+
+We may share information with:
+
+- **Service providers** who help us operate our website and services (e.g., hosting, analytics).
+- **Legal and safety** partners when required by law or to protect rights, safety, and property.
+- **Business transfers** in connection with a merger, acquisition, or asset sale.
+
+We do not sell your personal information.
+
+## International transfers
+
+Your information may be transferred to and processed in countries other than your own. We take steps to ensure appropriate safeguards are in place.
+
+## Your rights
+
+Depending on your location, you may have rights to access, correct, delete, or restrict processing of your personal data, and to object or withdraw consent. To exercise these rights, contact us using the details below.
+
+## Children's privacy
+
+Our services are not directed to children under 13 (or the minimum age required by local law). We do not knowingly collect personal information from children.
+
+## Changes to this policy
+
+We may update this Privacy Policy from time to time. We will post the updated version on this page with a new "Last updated" date.
+
+## Contact us
+
+If you have questions about this policy, please contact us at: privacy@dotui.org.

--- a/www/app/(legal)/terms-of-service/page.mdx
+++ b/www/app/(legal)/terms-of-service/page.mdx
@@ -1,0 +1,61 @@
+export const metadata = {
+	title: "Terms of Service",
+};
+
+# Terms of Service
+
+_Last updated: 2025-08-14_
+
+These Terms of Service ("Terms") govern your access to and use of dotUI (the "Service"). By using the Service, you agree to these Terms.
+
+## 1. Eligibility
+
+You must be capable of forming a binding contract and comply with these Terms and applicable laws.
+
+## 2. Accounts
+
+You are responsible for safeguarding your account credentials and for all activities under your account. Notify us immediately of any unauthorized use.
+
+## 3. Acceptable use
+
+You agree not to:
+
+- Use the Service for unlawful, infringing, or harmful purposes.
+- Interfere with or disrupt the Service or circumvent security measures.
+- Reverse engineer, modify, or create derivative works except as permitted by law.
+
+## 4. Content and ownership
+
+Unless otherwise noted, the Service and its content are protected by intellectual property laws. You retain ownership of any content you submit; you grant us a non-exclusive license to host and display that content solely to provide the Service.
+
+## 5. Third‑party services
+
+The Service may contain links or integrations to third‑party services. We are not responsible for their content, policies, or practices.
+
+## 6. Disclaimers
+
+The Service is provided "as is" without warranties of any kind. To the fullest extent permitted by law, we disclaim all warranties, express or implied, including merchantability, fitness for a particular purpose, and non‑infringement.
+
+## 7. Limitation of liability
+
+To the maximum extent permitted by law, we will not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues, whether incurred directly or indirectly, or any loss of data, use, goodwill, or other intangible losses.
+
+## 8. Indemnification
+
+You agree to indemnify and hold us harmless from any claims, liabilities, damages, losses, and expenses arising from your use of the Service or violation of these Terms.
+
+## 9. Termination
+
+We may suspend or terminate your access to the Service at any time, with or without notice, for any reason, including if you violate these Terms.
+
+## 10. Changes to these Terms
+
+We may modify these Terms from time to time. We will post the updated Terms on this page with a new "Last updated" date. Continued use of the Service after changes become effective constitutes acceptance.
+
+## 11. Governing law
+
+These Terms are governed by the laws of your jurisdiction of residence unless otherwise required by applicable law.
+
+## 12. Contact
+
+If you have questions about these Terms, contact us at: legal@dotui.org.

--- a/www/package.json
+++ b/www/package.json
@@ -79,6 +79,7 @@
     "@dotui/ts-config": "workspace:*",
     "@hookform/devtools": "^4.4.0",
     "@tailwindcss/postcss": "catalog:",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/estree": "^1.0.6",
     "@types/mdast": "^4.0.4",
     "@types/mdx": "^2.0.13",

--- a/www/styles/globals.css
+++ b/www/styles/globals.css
@@ -6,6 +6,7 @@
 
 @plugin "tailwindcss-react-aria-components";
 @plugin "tailwindcss-auto-contrast";
+@plugin "@tailwindcss/typography";
 
 @import "./docs.css";
 @import "@dotui/ui/focus-styles.css";


### PR DESCRIPTION
Add legal pages (Privacy Policy and Terms of Service) using route-based MDX with Tailwind Typography for proper styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8004d95-abec-40ed-9899-3153cc5ac7e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8004d95-abec-40ed-9899-3153cc5ac7e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

