### PR TITLE
Refactor style editor form structure

### DIFF
--- a/www/modules/styles/components/style-editor/nav.tsx
+++ b/www/modules/styles/components/style-editor/nav.tsx
@@ -2,16 +2,7 @@
 
 import React from "react";
 import { usePathname } from "next/navigation";
-import {
-  BoxesIcon,
-  BoxIcon,
-  ChevronDownIcon,
-  LayoutTemplateIcon,
-  PaletteIcon,
-  ShapesIcon,
-  SparklesIcon,
-  TypeIcon,
-} from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 
 import { Button } from "@dotui/ui/components/button";
 import { Menu, MenuItem, MenuRoot } from "@dotui/ui/components/menu";
@@ -23,6 +14,7 @@ import {
   Tabs,
 } from "@dotui/ui/registry/components/tabs/motion";
 import type { TabsProps } from "@dotui/ui/components/tabs";
+import { editorPlugins } from "@/modules/styles/editor/registry/registry";
 
 export function StyleEditorNav({
   children,
@@ -34,10 +26,13 @@ export function StyleEditorNav({
   const username = segments[2] ?? "";
   const styleName = segments[3] ?? "";
 
-  const menuItems = React.useMemo(
-    () => getMenuItems(username, styleName),
-    [username, styleName],
-  );
+  const menuItems = React.useMemo(() => {
+    return editorPlugins.map((plugin) => ({
+      href: plugin.route(username, styleName),
+      label: plugin.label,
+      icon: plugin.icon,
+    }));
+  }, [username, styleName]);
 
   const selectedTab = menuItems.find((item) => item.href === pathname);
 
@@ -91,35 +86,4 @@ export function StyleEditorNav({
   );
 }
 
-const getMenuItems = (username: string, styleName: string) => [
-  {
-    href: `/styles/${username}/${styleName}`,
-    label: "Colors",
-    icon: <PaletteIcon />,
-  },
-  {
-    href: `/styles/${username}/${styleName}/layout`,
-    label: "Layout",
-    icon: <LayoutTemplateIcon />,
-  },
-  {
-    href: `/styles/${username}/${styleName}/typography`,
-    label: "Typography",
-    icon: <TypeIcon />,
-  },
-  {
-    href: `/styles/${username}/${styleName}/components`,
-    label: "Components",
-    icon: <BoxIcon />,
-  },
-  {
-    href: `/styles/${username}/${styleName}/effects`,
-    label: "Effects",
-    icon: <SparklesIcon />,
-  },
-  {
-    href: `/styles/${username}/${styleName}/icons`,
-    label: "Icons",
-    icon: <ShapesIcon />,
-  },
-];
+// Menu items are now provided via the editor registry

--- a/www/modules/styles/editor/core/schema.ts
+++ b/www/modules/styles/editor/core/schema.ts
@@ -1,0 +1,175 @@
+"use client";
+
+import { z } from "zod";
+import { COLOR_TOKENS } from "@dotui/registry-definition/registry-tokens";
+import { styleDefinitionSchema } from "@dotui/style-engine/schemas";
+
+export const formSchema = styleDefinitionSchema.extend({
+	name: z.string().min(1),
+	slug: z.string().min(1),
+	description: z.string().nullable().optional(),
+	id: z.string().optional(),
+	userId: z.string().optional(),
+	createdAt: z.date().optional(),
+	updatedAt: z.date().nullable().optional(),
+	isFeatured: z.boolean().optional(),
+	visibility: z.enum(["public", "unlisted", "private"]).optional(),
+});
+
+export type StyleFormData = z.infer<typeof formSchema>;
+
+export const fakeData: StyleFormData = {
+	name: "Minimalist",
+	slug: "minimalist",
+	description: "",
+	theme: {
+		colors: {
+			activeModes: ["light", "dark"],
+			modes: {
+				light: {
+					lightness: 97,
+					saturation: 100,
+					contrast: 100,
+					scales: {
+						neutral: {
+							name: "neutral",
+							colorKeys: [{ id: 0, color: "#000000" }],
+							ratios: [1.05, 1.25, 1.7, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						accent: {
+							name: "accent",
+							colorKeys: [{ id: 0, color: "#0091FF" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						success: {
+							name: "success",
+							colorKeys: [{ id: 0, color: "#1A9338" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						warning: {
+							name: "warning",
+							colorKeys: [{ id: 0, color: "#E79D13" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						danger: {
+							name: "danger",
+							colorKeys: [{ id: 0, color: "#D93036" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						info: {
+							name: "info",
+							colorKeys: [{ id: 0, color: "#0091FF" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+					},
+				},
+				dark: {
+					lightness: 3,
+					saturation: 100,
+					contrast: 100,
+					scales: {
+						neutral: {
+							name: "neutral",
+							colorKeys: [{ id: 0, color: "#ffffff" }],
+							ratios: [1.05, 1.25, 1.7, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						accent: {
+							name: "accent",
+							colorKeys: [{ id: 0, color: "#0091FF" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						success: {
+							name: "success",
+							colorKeys: [{ id: 0, color: "#1A9338" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						warning: {
+							name: "warning",
+							colorKeys: [{ id: 0, color: "#E79D13" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						danger: {
+							name: "danger",
+							colorKeys: [{ id: 0, color: "#D93036" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+						info: {
+							name: "info",
+							colorKeys: [{ id: 0, color: "#0091FF" }],
+							ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
+							overrides: {},
+							smooth: false,
+						},
+					},
+				},
+			},
+			tokens: COLOR_TOKENS.map((token) => ({
+				id: token.name,
+				name: token.name,
+				value: token.defaultValue,
+			})),
+		},
+		radius: 1,
+		spacing: 0.25,
+		fonts: {
+			heading: "Inter",
+			body: "Inter",
+		},
+		letterSpacing: 0,
+		backgroundPattern: "none",
+		texture: "none",
+		shadows: {
+			color: "#000000",
+			opacity: 0.1,
+			blurRadius: 10,
+			offsetX: 0,
+			offsetY: 1,
+			spread: 0,
+		},
+	},
+	icons: {
+		library: "lucide",
+		strokeWidth: 1.5,
+	},
+	variants: {
+		alert: "basic",
+		buttons: "basic",
+		loader: "ring",
+		"focus-style": "basic",
+		inputs: "basic",
+		pickers: "basic",
+		selection: "basic",
+		calendars: "basic",
+		"list-box-and-menu": "basic",
+		overlays: "basic",
+		checkboxes: "basic",
+		radios: "basic",
+		switch: "basic",
+		slider: "basic",
+		"badge-and-tag-group": "basic",
+		tooltip: "basic",
+	},
+};
+

--- a/www/modules/styles/editor/core/useGeneratedTheme.ts
+++ b/www/modules/styles/editor/core/useGeneratedTheme.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import React from "react";
+import { useWatch, type UseFormReturn } from "react-hook-form";
+import type { ContrastColor } from "@adobe/leonardo-contrast-colors";
+
+import { createColorScales } from "@dotui/style-engine/core";
+
+import type { StyleFormData } from "./schema";
+
+export function useGeneratedTheme(
+	form: UseFormReturn<StyleFormData>,
+	resolvedMode: "light" | "dark",
+) {
+	const currentModeDefinition = useWatch({
+		name: `theme.colors.modes.${resolvedMode}`,
+		control: form.control,
+	});
+
+	const generatedTheme: ContrastColor[] = React.useMemo(() => {
+		const theme = createColorScales(currentModeDefinition);
+		return theme;
+	}, [currentModeDefinition]);
+
+	return generatedTheme;
+}
+

--- a/www/modules/styles/editor/core/useLivePreviewSync.ts
+++ b/www/modules/styles/editor/core/useLivePreviewSync.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import React from "react";
+import { useWatch, type UseFormReturn } from "react-hook-form";
+
+import { useDebounce } from "@/hooks/use-debounce";
+import { useLiveStyleProducer } from "@/modules/styles/atoms/live-style-atom";
+
+import type { StyleFormData } from "./schema";
+
+export function useLivePreviewSync(
+	form: UseFormReturn<StyleFormData>,
+	styleKey: string,
+	shouldSync: boolean,
+) {
+	const { updateLiveStyle } = useLiveStyleProducer(styleKey);
+	const watchedValues = useWatch({ control: form.control }) as
+		| StyleFormData
+		| undefined;
+	const debounced = useDebounce(watchedValues, 30);
+
+	React.useEffect(() => {
+		if (shouldSync && debounced) {
+			updateLiveStyle(debounced);
+		}
+	}, [debounced, shouldSync, updateLiveStyle]);
+}
+

--- a/www/modules/styles/editor/core/useResolvedMode.ts
+++ b/www/modules/styles/editor/core/useResolvedMode.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import React from "react";
+import { useWatch, type UseFormReturn } from "react-hook-form";
+
+import { usePreferences } from "@/modules/styles/atoms/preferences-atom";
+import type { StyleFormData } from "./schema";
+
+export function useResolvedMode(form: UseFormReturn<StyleFormData>) {
+	const { activeMode } = usePreferences();
+	const watchedActiveModes = useWatch({
+		name: "theme.colors.activeModes",
+		control: form.control,
+	});
+
+	const resolvedMode: "light" | "dark" = React.useMemo(() => {
+		if (
+			watchedActiveModes.includes("light") &&
+			watchedActiveModes.includes("dark")
+		)
+			return activeMode;
+		return watchedActiveModes[0]!;
+	}, [watchedActiveModes, activeMode]);
+
+	return resolvedMode;
+}
+

--- a/www/modules/styles/editor/core/useSaveStyle.ts
+++ b/www/modules/styles/editor/core/useSaveStyle.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@dotui/ui/components/toast";
+
+import { useTRPC, useTRPCClient } from "@/lib/trpc/react";
+import type { StyleFormData } from "./schema";
+
+export function useSaveStyle(params: {
+	styleId: string;
+	styleName: string;
+	username: string;
+}) {
+	const { styleId, styleName, username } = params;
+	const trpc = useTRPC();
+	const trpcClient = useTRPCClient();
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation({
+		mutationFn: async (data: StyleFormData) => {
+			if (!styleId) throw new Error("Missing style id");
+			return await trpcClient.style.update.mutate({
+				id: styleId,
+				theme: data.theme,
+				icons: data.icons,
+				variants: data.variants,
+			});
+		},
+		onMutate: async (variables: StyleFormData) => {
+			const queryKey = trpc.style.getByNameAndUsername.queryKey({
+				name: styleName,
+				username,
+			});
+			await queryClient.cancelQueries({ queryKey });
+			const previousStyle = queryClient.getQueryData(queryKey);
+			queryClient.setQueryData(queryKey, (old: any) => {
+				if (!old) return old;
+				return {
+					...old,
+					theme: variables.theme,
+					icons: variables.icons,
+					variants: variables.variants,
+					updatedAt: new Date(),
+				};
+			});
+			return { previousStyle, queryKey } as const;
+		},
+		onError: (_error: unknown, _variables, context) => {
+			if (context?.previousStyle) {
+				queryClient.setQueryData(context.queryKey, context.previousStyle);
+			}
+			toast.add({ title: "Failed to update style", variant: "danger" });
+		},
+		onSuccess: (updated: any) => {
+			const queryKey = trpc.style.getByNameAndUsername.queryKey({
+				name: styleName,
+				username,
+			});
+			queryClient.setQueryData(queryKey, updated);
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({
+				queryKey: trpc.style.getByNameAndUsername.queryKey({
+					name: styleName,
+					username,
+				}),
+			});
+		},
+	});
+
+	return mutation;
+}
+

--- a/www/modules/styles/editor/core/useStyleForm.ts
+++ b/www/modules/styles/editor/core/useStyleForm.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+
+import { fakeData, formSchema, type StyleFormData } from "./schema";
+
+export function useStyleForm(style?: Partial<StyleFormData> | null) {
+	const form = useForm<StyleFormData>({
+		resolver: zodResolver(formSchema),
+		defaultValues: fakeData,
+		values: style ? { ...(style as any), slug: (style as any).name } : undefined,
+	});
+	return form;
+}
+
+export type { StyleFormData };
+

--- a/www/modules/styles/editor/core/useStyleQuery.ts
+++ b/www/modules/styles/editor/core/useStyleQuery.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+
+import { useTRPC } from "@/lib/trpc/react";
+
+export function useStyleQuery() {
+	const pathname = usePathname();
+	const segments = pathname.split("/");
+	const username = segments[2] ?? "";
+	const styleName = segments[3] ?? "";
+
+	const trpc = useTRPC();
+	const query = useQuery(
+		trpc.style.getByNameAndUsername.queryOptions({
+			name: styleName,
+			username,
+		}),
+	);
+
+	return { ...query, username, styleName } as const;
+}
+

--- a/www/modules/styles/editor/registry/registry.tsx
+++ b/www/modules/styles/editor/registry/registry.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import {
+	PaletteIcon,
+	LayoutTemplateIcon,
+	TypeIcon,
+	BoxIcon,
+	SparklesIcon,
+	ShapesIcon,
+} from "lucide-react";
+
+import type { EditorPlugin } from "./types";
+
+// Temporary: wrap existing monolithic editors as single sections.
+import { ColorsEditor } from "@/modules/styles/components/style-editor/colors-editor";
+import { LayoutEditor } from "@/modules/styles/components/style-editor/layout-editor";
+import { TypographyEditor } from "@/modules/styles/components/style-editor/style-typography-editor";
+import { ComponentsEditor } from "@/modules/styles/components/style-editor/components-editor";
+import { EffectsEditor } from "@/modules/styles/components/style-editor/effects-editor";
+import { IconsEditor } from "@/modules/styles/components/style-editor/icons-editor";
+
+function wrapAsSingleSection(
+	id: string,
+	title: string,
+	Comp: React.ComponentType,
+): EditorPlugin["sections"] {
+	return [
+		{
+			id,
+			title,
+			Component: Comp,
+		},
+	];
+}
+
+export const editorPlugins: EditorPlugin[] = [
+	{
+		id: "colors",
+		label: "Colors",
+		route: (u, s) => `/styles/${u}/${s}`,
+		icon: <PaletteIcon />,
+		sections: wrapAsSingleSection("colors-root", "Colors", ColorsEditor),
+	},
+	{
+		id: "layout",
+		label: "Layout",
+		route: (u, s) => `/styles/${u}/${s}/layout`,
+		icon: <LayoutTemplateIcon />,
+		sections: wrapAsSingleSection("layout-root", "Layout", LayoutEditor),
+	},
+	{
+		id: "typography",
+		label: "Typography",
+		route: (u, s) => `/styles/${u}/${s}/typography`,
+		icon: <TypeIcon />,
+		sections: wrapAsSingleSection(
+			"typography-root",
+			"Typography",
+			TypographyEditor,
+		),
+	},
+	{
+		id: "components",
+		label: "Components",
+		route: (u, s) => `/styles/${u}/${s}/components`,
+		icon: <BoxIcon />,
+		sections: wrapAsSingleSection(
+			"components-root",
+			"Components",
+			ComponentsEditor,
+		),
+	},
+	{
+		id: "effects",
+		label: "Effects",
+		route: (u, s) => `/styles/${u}/${s}/effects`,
+		icon: <SparklesIcon />,
+		sections: wrapAsSingleSection("effects-root", "Effects", EffectsEditor),
+	},
+	{
+		id: "icons",
+		label: "Icons",
+		route: (u, s) => `/styles/${u}/${s}/icons`,
+		icon: <ShapesIcon />,
+		sections: wrapAsSingleSection("icons-root", "Icons", IconsEditor),
+	},
+];
+

--- a/www/modules/styles/editor/registry/types.ts
+++ b/www/modules/styles/editor/registry/types.ts
@@ -1,0 +1,16 @@
+import React from "react";
+
+export interface EditorSection {
+	id: string;
+	title: string;
+	Component: React.ComponentType;
+}
+
+export interface EditorPlugin {
+	id: string;
+	label: string;
+	route: (username: string, styleName: string) => string;
+	icon: React.ReactNode;
+	sections: EditorSection[];
+}
+

--- a/www/modules/styles/providers/style-editor-provider.tsx
+++ b/www/modules/styles/providers/style-editor-provider.tsx
@@ -2,36 +2,20 @@
 
 import React from "react";
 import { usePathname } from "next/navigation";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useForm, useWatch } from "react-hook-form";
-import { z } from "zod";
 import type { ContrastColor } from "@adobe/leonardo-contrast-colors";
 import type { UseFormReturn } from "react-hook-form";
 
-import { COLOR_TOKENS } from "@dotui/registry-definition/registry-tokens";
-import { createColorScales } from "@dotui/style-engine/core";
-import { styleDefinitionSchema } from "@dotui/style-engine/schemas";
-import { toast } from "@dotui/ui/components/toast";
-
-import { useDebounce } from "@/hooks/use-debounce";
-import { useTRPC, useTRPCClient } from "@/lib/trpc/react";
-import { useLiveStyleProducer } from "../atoms/live-style-atom";
-import { usePreferences } from "../atoms/preferences-atom";
-
-const formSchema = styleDefinitionSchema.extend({
-  name: z.string().min(1),
-  slug: z.string().min(1),
-  description: z.string().nullable().optional(),
-  id: z.string().optional(),
-  userId: z.string().optional(),
-  createdAt: z.date().optional(),
-  updatedAt: z.date().nullable().optional(),
-  isFeatured: z.boolean().optional(),
-  visibility: z.enum(["public", "unlisted", "private"]).optional(),
-});
-
-export type StyleFormData = z.infer<typeof formSchema>;
+import {
+  fakeData,
+  formSchema,
+  type StyleFormData,
+} from "@/modules/styles/editor/core/schema";
+import { useStyleQuery } from "@/modules/styles/editor/core/useStyleQuery";
+import { useStyleForm as useStyleFormCore } from "@/modules/styles/editor/core/useStyleForm";
+import { useResolvedMode } from "@/modules/styles/editor/core/useResolvedMode";
+import { useGeneratedTheme } from "@/modules/styles/editor/core/useGeneratedTheme";
+import { useLivePreviewSync } from "@/modules/styles/editor/core/useLivePreviewSync";
+import { useSaveStyle } from "@/modules/styles/editor/core/useSaveStyle";
 
 interface StyleFormContextType {
   form: UseFormReturn<StyleFormData>;
@@ -48,7 +32,6 @@ const StyleFormContext = React.createContext<StyleFormContextType | null>(null);
 
 export function useStyleForm() {
   const context = React.useContext(StyleFormContext);
-
   if (!context) {
     throw new Error("useStyleForm must be used within a StyleFormProvider");
   }
@@ -60,75 +43,24 @@ export function StyleEditorProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const segments = pathname.split("/");
-  const username = segments[2] ?? "";
-  const styleName = segments[3] ?? "";
+  const { data: style, isLoading, isError, isSuccess, username, styleName } =
+    useStyleQuery();
 
-  const { activeMode } = usePreferences();
-  const { updateLiveStyle } = useLiveStyleProducer(`${username}/${styleName}`);
+  const form = useStyleFormCore(style ?? undefined);
 
-  const trpc = useTRPC();
-  const {
-    data: style,
-    isLoading,
-    isError,
-    isSuccess,
-  } = useQuery(
-    trpc.style.getByNameAndUsername.queryOptions({
-      name: styleName,
-      username,
-    }),
-  );
+  const resolvedMode = useResolvedMode(form);
+  const generatedTheme = useGeneratedTheme(form, resolvedMode);
 
-  const form = useForm<StyleFormData>({
-    resolver: zodResolver(formSchema),
-    defaultValues: fakeData,
-    values: style ? { ...style, slug: style.name } : undefined,
-  });
-
-  const watchedValues = useWatch({ control: form.control }) as
-    | StyleFormData
-    | undefined;
-
-  const debouncedWatchedValues = useDebounce(watchedValues, 30);
-  const watchedActiveModes = useWatch({
-    name: "theme.colors.activeModes",
-    control: form.control,
-  });
-
-  const resolvedMode: "light" | "dark" = React.useMemo(() => {
-    if (
-      watchedActiveModes.includes("light") &&
-      watchedActiveModes.includes("dark")
-    )
-      return activeMode;
-    return watchedActiveModes[0]!;
-  }, [watchedActiveModes, activeMode]);
-
-  const currentModeDefinition = useWatch({
-    name: `theme.colors.modes.${resolvedMode}`,
-    control: form.control,
-  });
-
-  const generatedTheme = React.useMemo(() => {
-    const theme = createColorScales(currentModeDefinition);
-    return theme;
-  }, [currentModeDefinition]);
-
-  React.useEffect(() => {
-    if (isSuccess && debouncedWatchedValues) {
-      updateLiveStyle(debouncedWatchedValues);
-    }
-  }, [debouncedWatchedValues, updateLiveStyle, isSuccess]);
+  useLivePreviewSync(form, `${username}/${styleName}`, isSuccess);
 
   return (
     <StyleFormContext.Provider
       value={{
         form,
-        slug: (style?.visibility === "public"
-          ? `${username}/${style?.name}`
-          : style?.name)!,
+        slug:
+          (style?.visibility === "public"
+            ? `${username}/${style?.name}`
+            : style?.name) ?? "",
         styleId: style?.id ?? "",
         resolvedMode,
         generatedTheme,
@@ -144,90 +76,20 @@ export function StyleEditorProvider({
 
 export function StyleEditorForm({ children }: { children: React.ReactNode }) {
   const { form, styleId } = useStyleForm();
-  const trpc = useTRPC();
-  const trpcClient = useTRPCClient();
-  const queryClient = useQueryClient();
-
   const pathname = usePathname();
   const segments = pathname.split("/");
   const username = segments[2] ?? "";
   const styleName = segments[3] ?? "";
 
-  const updateStyleMutation = useMutation({
-    mutationFn: async (data: StyleFormData) => {
-      if (!styleId) throw new Error("Missing style id");
-      return await trpcClient.style.update.mutate({
-        id: styleId,
-        theme: data.theme,
-        icons: data.icons,
-        variants: data.variants,
-      });
-    },
-    onMutate: async (variables: StyleFormData) => {
-      const queryKey = trpc.style.getByNameAndUsername.queryKey({
-        name: styleName,
-        username,
-      });
-
-      await queryClient.cancelQueries({ queryKey });
-
-      const previousStyle = queryClient.getQueryData(queryKey);
-
-      queryClient.setQueryData(queryKey, (old: any) => {
-        if (!old) return old;
-        return {
-          ...old,
-          theme: variables.theme,
-          icons: variables.icons,
-          variants: variables.variants,
-          updatedAt: new Date(),
-        };
-      });
-
-      return { previousStyle, queryKey } as const;
-    },
-    onError: (error: unknown, _variables, context) => {
-      if (context?.previousStyle) {
-        queryClient.setQueryData(context.queryKey, context.previousStyle);
-      }
-      toast.add({
-        title: "Failed to update style",
-        variant: "danger",
-      });
-    },
-    onSuccess: (updated: any) => {
-      const queryKey = trpc.style.getByNameAndUsername.queryKey({
-        name: styleName,
-        username,
-      });
-      queryClient.setQueryData(queryKey, updated);
-      if (updated) {
-        const nextValues = { ...updated, slug: updated.name } as StyleFormData;
-        form.reset(
-          {
-            ...nextValues,
-            description:
-              nextValues.description ?? form.getValues("description"),
-            userId: nextValues.userId ?? form.getValues("userId"),
-          },
-          { keepDirty: false },
-        );
-      }
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: trpc.style.getByNameAndUsername.queryKey({
-          name: styleName,
-          username,
-        }),
-      });
-    },
+  const updateStyleMutation = useSaveStyle({
+    styleId,
+    styleName,
+    username,
   });
 
   const handleSubmit = form.handleSubmit(
     async (data) => {
       try {
-        console.log("🔄 Submitting style update...");
         await updateStyleMutation.mutateAsync(data);
       } catch (error) {
         console.error("Submission failed:", error);
@@ -240,158 +102,3 @@ export function StyleEditorForm({ children }: { children: React.ReactNode }) {
 
   return <form onSubmit={handleSubmit}>{children}</form>;
 }
-
-const fakeData: StyleFormData = {
-  name: "Minimalist",
-  slug: "minimalist",
-  description: "",
-  theme: {
-    colors: {
-      activeModes: ["light", "dark"],
-      modes: {
-        light: {
-          lightness: 97,
-          saturation: 100,
-          contrast: 100,
-          scales: {
-            neutral: {
-              name: "neutral",
-              colorKeys: [{ id: 0, color: "#000000" }],
-              ratios: [1.05, 1.25, 1.7, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            accent: {
-              name: "accent",
-              colorKeys: [{ id: 0, color: "#0091FF" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            success: {
-              name: "success",
-              colorKeys: [{ id: 0, color: "#1A9338" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            warning: {
-              name: "warning",
-              colorKeys: [{ id: 0, color: "#E79D13" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            danger: {
-              name: "danger",
-              colorKeys: [{ id: 0, color: "#D93036" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            info: {
-              name: "info",
-              colorKeys: [{ id: 0, color: "#0091FF" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-          },
-        },
-        dark: {
-          lightness: 3,
-          saturation: 100,
-          contrast: 100,
-          scales: {
-            neutral: {
-              name: "neutral",
-              colorKeys: [{ id: 0, color: "#ffffff" }],
-              ratios: [1.05, 1.25, 1.7, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            accent: {
-              name: "accent",
-              colorKeys: [{ id: 0, color: "#0091FF" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            success: {
-              name: "success",
-              colorKeys: [{ id: 0, color: "#1A9338" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            warning: {
-              name: "warning",
-              colorKeys: [{ id: 0, color: "#E79D13" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            danger: {
-              name: "danger",
-              colorKeys: [{ id: 0, color: "#D93036" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-            info: {
-              name: "info",
-              colorKeys: [{ id: 0, color: "#0091FF" }],
-              ratios: [1.25, 1.5, 1.8, 2.25, 3.15, 4.8, 6.35, 8.3, 13.2, 15.2],
-              overrides: {},
-              smooth: false,
-            },
-          },
-        },
-      },
-      tokens: COLOR_TOKENS.map((token) => ({
-        id: token.name,
-        name: token.name,
-        value: token.defaultValue,
-      })),
-    },
-    radius: 1,
-    spacing: 0.25,
-    fonts: {
-      heading: "Inter",
-      body: "Inter",
-    },
-    letterSpacing: 0,
-    backgroundPattern: "none",
-    texture: "none",
-    shadows: {
-      color: "#000000",
-      opacity: 0.1,
-      blurRadius: 10,
-      offsetX: 0,
-      offsetY: 1,
-      spread: 0,
-    },
-  },
-  icons: {
-    library: "lucide",
-    strokeWidth: 1.5,
-  },
-  variants: {
-    alert: "basic",
-    buttons: "basic",
-    loader: "ring",
-    "focus-style": "basic",
-    inputs: "basic",
-    pickers: "basic",
-    selection: "basic",
-    calendars: "basic",
-    "list-box-and-menu": "basic",
-    overlays: "basic",
-    checkboxes: "basic",
-    radios: "basic",
-    switch: "basic",
-    slider: "basic",
-    "badge-and-tag-group": "basic",
-    tooltip: "basic",
-  },
-};


### PR DESCRIPTION
Extract core style editor logic into granular hooks and make navigation registry-driven to improve structure and maintainability.

The `StyleEditorProvider` was a monolithic component responsible for data fetching, form state, derived values, and mutations. This PR refactors these concerns into dedicated, reusable hooks and introduces a registry-driven navigation system, which simplifies the main provider and makes adding new editor sections more modular.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0a24221-7837-4079-b527-28ac145885ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0a24221-7837-4079-b527-28ac145885ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

