### PR TITLE
Fix nextjs typed route navigation error

### DIFF
--- a/www/app/providers.tsx
+++ b/www/app/providers.tsx
@@ -20,7 +20,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   return (
     <JotaiProvider>
-      <RouterProvider navigate={router.push}>
+      <RouterProvider navigate={(path, options) => router.push(path as any, options)}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"


### PR DESCRIPTION
Wrap `router.push` to resolve type incompatibility with `RouterProvider` due to Next.js typed routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-53eff0e4-e964-463d-9f3c-8b9ed634acb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53eff0e4-e964-463d-9f3c-8b9ed634acb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

