### PR TITLE
feat(www): implement fullscreen in preview toolbar

### DIFF
--- a/packages/ui/src/lib/utils.tsx
+++ b/packages/ui/src/lib/utils.tsx
@@ -7,8 +7,9 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export type SlotsToClassNames<T extends (...args: any[]) => any> =
-  Partial<Record<keyof ReturnType<T>, ClassValue>>;
+export type SlotsToClassNames<T extends (...args: any[]) => any> = Partial<
+  Record<keyof ReturnType<T>, ClassValue>
+>;
 
 export function createScopedContext<ContextValueType extends object | null>(
   rootComponentName: string,

--- a/packages/ui/src/lib/utils.tsx
+++ b/packages/ui/src/lib/utils.tsx
@@ -7,6 +7,9 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export type SlotsToClassNames<T extends (...args: any[]) => any> =
+  Partial<Record<keyof ReturnType<T>, ClassValue>>;
+
 export function createScopedContext<ContextValueType extends object | null>(
   rootComponentName: string,
   defaultContext?: ContextValueType,

--- a/packages/ui/src/registry/components/modal/basic.tsx
+++ b/packages/ui/src/registry/components/modal/basic.tsx
@@ -8,28 +8,33 @@ import {
 } from "react-aria-components";
 import { tv } from "tailwind-variants";
 
+import type { SlotsToClassNames } from "@dotui/ui/lib/utils";
+
 const modalStyles = tv({
   slots: {
-    underlay:
-      "h-(--visual-viewport-height) bg-bg-inverse/40 dark:bg-bg/40 entering:opacity-0 exiting:opacity-0 fixed left-0 top-0 z-50 flex w-screen items-center justify-center opacity-100 duration-200 ease-[cubic-bezier(0.165,0.84,0.44,1)] will-change-[opacity]",
     overlay:
+      "h-(--visual-viewport-height) bg-bg-inverse/40 dark:bg-bg/40 entering:opacity-0 exiting:opacity-0 fixed left-0 top-0 z-50 flex w-screen items-center justify-center opacity-100 duration-200 ease-[cubic-bezier(0.165,0.84,0.44,1)] will-change-[opacity]",
+    modal:
       "bg-bg entering:scale-95 exiting:scale-95 relative z-50 w-full max-w-lg scale-100 border shadow-lg duration-200 ease-[cubic-bezier(0.165,0.84,0.44,1)] will-change-transform sm:rounded-lg md:w-full",
   },
 });
 
-const { underlay, overlay } = modalStyles();
+const { overlay, modal } = modalStyles();
 
-interface ModalProps extends React.ComponentProps<typeof AriaModal> {}
+interface ModalProps extends React.ComponentProps<typeof AriaModal> {
+  classNames?: SlotsToClassNames<typeof modalStyles>;
+}
+
 const Modal = ({ className, isDismissable = true, ...props }: ModalProps) => (
   <AriaModalOverlay
     isDismissable={isDismissable}
-    className={composeRenderProps(className, (className) => underlay({}))}
+    className={composeRenderProps(className, (className) => overlay({}))}
     {...props}
   >
     <AriaModal
       isDismissable={isDismissable}
       className={composeRenderProps(className, (className) =>
-        overlay({ className }),
+        modal({ className }),
       )}
       {...props}
     />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,10 +559,10 @@ importers:
         version: 15.3.4(bufferutil@4.0.9)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
-        version: 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.1.12(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-scroll-area':
         specifier: ^1.0.5
-        version: 1.2.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.2.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-aria/overlays':
         specifier: ^3.27.1
         version: 3.27.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -663,8 +663,8 @@ importers:
         specifier: ^0.33.2
         version: 0.33.5
       shiki:
-        specifier: ^3.8.1
-        version: 3.8.1
+        specifier: ^3.12.2
+        version: 3.12.2
       superjson:
         specifier: 2.2.2
         version: 2.2.2
@@ -2559,9 +2559,6 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
-  '@radix-ui/primitive@1.1.2':
-    resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
-
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -2580,19 +2577,6 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-collapsible@1.1.11':
-    resolution: {integrity: sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2766,19 +2750,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-presence@1.1.4':
-    resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
@@ -2820,19 +2791,6 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.10':
     resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-scroll-area@1.2.9':
-    resolution: {integrity: sha512-YSjEfBXnhUELsO2VzjdtYYD4CfQjvao+lhhrX5XsHD7/cyUNzljF1FHEbgTPN7LH2MClfwRMIsYlqTYpKTTe2A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3654,26 +3612,14 @@ packages:
   '@shikijs/core@3.12.2':
     resolution: {integrity: sha512-L1Safnhra3tX/oJK5kYHaWmLEBJi1irASwewzY3taX5ibyXyMkkSDZlq01qigjryOBwrXSdFgTiZ3ryzSNeu7Q==}
 
-  '@shikijs/core@3.8.1':
-    resolution: {integrity: sha512-uTSXzUBQ/IgFcUa6gmGShCHr4tMdR3pxUiiWKDm8pd42UKJdYhkAYsAmHX5mTwybQ5VyGDgTjW4qKSsRvGSang==}
-
   '@shikijs/engine-javascript@3.12.2':
     resolution: {integrity: sha512-Nm3/azSsaVS7hk6EwtHEnTythjQfwvrO5tKqMlaH9TwG1P+PNaR8M0EAKZ+GaH2DFwvcr4iSfTveyxMIvXEHMw==}
-
-  '@shikijs/engine-javascript@3.8.1':
-    resolution: {integrity: sha512-rZRp3BM1llrHkuBPAdYAzjlF7OqlM0rm/7EWASeCcY7cRYZIrOnGIHE9qsLz5TCjGefxBFnwgIECzBs2vmOyKA==}
 
   '@shikijs/engine-oniguruma@3.12.2':
     resolution: {integrity: sha512-hozwnFHsLvujK4/CPVHNo3Bcg2EsnG8krI/ZQ2FlBlCRpPZW4XAEQmEwqegJsypsTAN9ehu2tEYe30lYKSZW/w==}
 
-  '@shikijs/engine-oniguruma@3.8.1':
-    resolution: {integrity: sha512-KGQJZHlNY7c656qPFEQpIoqOuC4LrxjyNndRdzk5WKB/Ie87+NJCF1xo9KkOUxwxylk7rT6nhlZyTGTC4fCe1g==}
-
   '@shikijs/langs@3.12.2':
     resolution: {integrity: sha512-bVx5PfuZHDSHoBal+KzJZGheFuyH4qwwcwG/n+MsWno5cTlKmaNtTsGzJpHYQ8YPbB5BdEdKU1rga5/6JGY8ww==}
-
-  '@shikijs/langs@3.8.1':
-    resolution: {integrity: sha512-TjOFg2Wp1w07oKnXjs0AUMb4kJvujML+fJ1C5cmEj45lhjbUXtziT1x2bPQb9Db6kmPhkG5NI2tgYW1/DzhUuQ==}
 
   '@shikijs/rehype@3.12.2':
     resolution: {integrity: sha512-9wg+FKv0ByaQScTonpZdrDhADOoJP/yCWLAuiYYG6GehwNV5rGwnLvWKj33UmtLedKMSHzWUdB+Un6rfDFo/FA==}
@@ -3681,17 +3627,11 @@ packages:
   '@shikijs/themes@3.12.2':
     resolution: {integrity: sha512-fTR3QAgnwYpfGczpIbzPjlRnxyONJOerguQv1iwpyQZ9QXX4qy/XFQqXlf17XTsorxnHoJGbH/LXBvwtqDsF5A==}
 
-  '@shikijs/themes@3.8.1':
-    resolution: {integrity: sha512-Vu3t3BBLifc0GB0UPg2Pox1naTemrrvyZv2lkiSw3QayVV60me1ujFQwPZGgUTmwXl1yhCPW8Lieesm0CYruLQ==}
-
   '@shikijs/transformers@3.12.2':
     resolution: {integrity: sha512-+z1aMq4N5RoNGY8i7qnTYmG2MBYzFmwkm/yOd6cjEI7OVzcldVvzQCfxU1YbIVgsyB0xHVc2jFe1JhgoXyUoSQ==}
 
   '@shikijs/types@3.12.2':
     resolution: {integrity: sha512-K5UIBzxCyv0YoxN3LMrKB9zuhp1bV+LgewxuVwHdl4Gz5oePoUFrr9EfgJlGlDeXCU1b/yhdnXeuRvAnz8HN8Q==}
-
-  '@shikijs/types@3.8.1':
-    resolution: {integrity: sha512-5C39Q8/8r1I26suLh+5TPk1DTrbY/kn3IdWA5HdizR0FhlhD05zx5nKCqhzSfDHH3p4S0ZefxWd77DLV+8FhGg==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -7488,9 +7428,6 @@ packages:
   shiki@3.12.2:
     resolution: {integrity: sha512-uIrKI+f9IPz1zDT+GMz+0RjzKJiijVr6WDWm9Pe3NNY6QigKCfifCEv9v9R2mDASKKjzjQ2QpFLcxaR3iHSnMA==}
 
-  shiki@3.8.1:
-    resolution: {integrity: sha512-+MYIyjwGPCaegbpBeFN9+oOifI8CKiKG3awI/6h3JeT85c//H2wDW/xCJEGuQ5jPqtbboKNqNy+JyX9PYpGwNg==}
-
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -10052,8 +9989,6 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
-  '@radix-ui/primitive@1.1.2': {}
-
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
@@ -10076,22 +10011,6 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-collapsible@1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
@@ -10276,16 +10195,6 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
-  '@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
   '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
@@ -10330,23 +10239,6 @@ snapshots:
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
       '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
@@ -11562,22 +11454,9 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/core@3.8.1':
-    dependencies:
-      '@shikijs/types': 3.8.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
   '@shikijs/engine-javascript@3.12.2':
     dependencies:
       '@shikijs/types': 3.12.2
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.3
-
-  '@shikijs/engine-javascript@3.8.1':
-    dependencies:
-      '@shikijs/types': 3.8.1
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.3
 
@@ -11586,18 +11465,9 @@ snapshots:
       '@shikijs/types': 3.12.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@3.8.1':
-    dependencies:
-      '@shikijs/types': 3.8.1
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/langs@3.12.2':
     dependencies:
       '@shikijs/types': 3.12.2
-
-  '@shikijs/langs@3.8.1':
-    dependencies:
-      '@shikijs/types': 3.8.1
 
   '@shikijs/rehype@3.12.2':
     dependencies:
@@ -11612,21 +11482,12 @@ snapshots:
     dependencies:
       '@shikijs/types': 3.12.2
 
-  '@shikijs/themes@3.8.1':
-    dependencies:
-      '@shikijs/types': 3.8.1
-
   '@shikijs/transformers@3.12.2':
     dependencies:
       '@shikijs/core': 3.12.2
       '@shikijs/types': 3.12.2
 
   '@shikijs/types@3.12.2':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  '@shikijs/types@3.8.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -16268,17 +16129,6 @@ snapshots:
       '@shikijs/langs': 3.12.2
       '@shikijs/themes': 3.12.2
       '@shikijs/types': 3.12.2
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  shiki@3.8.1:
-    dependencies:
-      '@shikijs/core': 3.8.1
-      '@shikijs/engine-javascript': 3.8.1
-      '@shikijs/engine-oniguruma': 3.8.1
-      '@shikijs/langs': 3.8.1
-      '@shikijs/themes': 3.8.1
-      '@shikijs/types': 3.8.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 

--- a/www/components/preview.tsx
+++ b/www/components/preview.tsx
@@ -7,6 +7,7 @@ import {
   ChevronsUpDownIcon,
   ExternalLinkIcon,
   MaximizeIcon,
+  MinimizeIcon,
   SmartphoneIcon,
   TabletIcon,
 } from "lucide-react";
@@ -136,6 +137,8 @@ export function PreviewContent({
   setWidth: (width: number) => void;
   currentWidth: number;
 }) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = React.useState(false);
   const isMobile = currentWidth < 480;
   const pathname = usePathname();
   const segments = pathname.split("/");
@@ -150,8 +153,32 @@ export function PreviewContent({
     setLoading(true);
   }, [currentBlockName]);
 
+  React.useEffect(() => {
+    const handleFullscreenChange = () => {
+      const isActive = document.fullscreenElement === containerRef.current;
+      setIsFullscreen(isActive);
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    };
+  }, []);
+
+  const toggleFullscreen = async () => {
+    try {
+      if (!isFullscreen) {
+        await containerRef.current?.requestFullscreen?.();
+      } else {
+        await document.exitFullscreen?.();
+      }
+    } catch (_) {
+      // ignore
+    }
+  };
+
   return (
     <div
+      ref={containerRef}
       className={cn(
         "bg-bg size-full overflow-hidden rounded-md border",
         className,
@@ -240,15 +267,16 @@ export function PreviewContent({
               <ExternalLinkIcon />
             </Button>
           </Tooltip>
-          <Tooltip content="Maximize" delay={0}>
+          <Tooltip content={isFullscreen ? "Exit fullscreen" : "Fullscreen"} delay={0}>
             <Button
-              aria-label="Maximize"
+              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
               variant="quiet"
               shape="square"
               size="sm"
               className="size-7"
+              onPress={toggleFullscreen}
             >
-              <MaximizeIcon />
+              {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
             </Button>
           </Tooltip>
         </div>

--- a/www/components/preview.tsx
+++ b/www/components/preview.tsx
@@ -18,6 +18,7 @@ import {
   registryBlocks,
 } from "@dotui/registry-definition/registry-blocks";
 import { Button } from "@dotui/ui/components/button";
+import { Dialog, DialogRoot } from "@dotui/ui/components/dialog";
 import {
   ListBox,
   ListBoxItem,
@@ -153,27 +154,16 @@ export function PreviewContent({
     setLoading(true);
   }, [currentBlockName]);
 
-  // CSS-only fullscreen overlay; no Fullscreen API
-  React.useEffect(() => {
-    const root = document.documentElement;
-    if (isFullscreen) {
-      root.classList.add("overflow-hidden");
-    } else {
-      root.classList.remove("overflow-hidden");
-    }
-    return () => root.classList.remove("overflow-hidden");
-  }, [isFullscreen]);
-
-  return (
-    <div
-      ref={containerRef}
-      className={cn(
-        "bg-bg size-full overflow-hidden rounded-md border",
-        isFullscreen &&
-          "fixed inset-0 z-50 rounded-none p-4 md:p-8 animate-in zoom-in-90",
-        className,
-      )}
-    >
+  function PreviewToolbar({
+    onToggleDevice,
+    onOpenNewTab,
+    onEnterFullscreen,
+  }: {
+    onToggleDevice: () => void;
+    onOpenNewTab: () => void;
+    onEnterFullscreen?: () => void;
+  }) {
+    return (
       <div className="bg-bg-muted/50 flex items-center justify-between gap-2 border-b border-t-[inherit] px-1 py-1">
         <div className="flex items-center gap-1">
           {collapsible && (
@@ -237,9 +227,7 @@ export function PreviewContent({
               shape="square"
               size="sm"
               className="size-7"
-              onPress={() => {
-                setWidth(isMobile ? 768 : 430);
-              }}
+              onPress={onToggleDevice}
             >
               {isMobile ? <SmartphoneIcon /> : <TabletIcon />}
             </Button>
@@ -247,30 +235,38 @@ export function PreviewContent({
           <Tooltip content="Open in new tab" delay={0}>
             <Button
               aria-label="Open in new tab"
-              href={`/view/${username}/${styleName}/${currentBlockName}`}
               target="_blank"
               variant="quiet"
               shape="square"
               size="sm"
               className="size-7"
+              href={`/view/${username}/${styleName}/${currentBlockName}`}
+              onPress={onOpenNewTab}
             >
               <ExternalLinkIcon />
             </Button>
           </Tooltip>
-          <Tooltip content={isFullscreen ? "Exit fullscreen" : "Fullscreen"} delay={0}>
-            <Button
-              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-              variant="quiet"
-              shape="square"
-              size="sm"
-              className="size-7"
-              onPress={() => setIsFullscreen((v) => !v)}
-            >
-              {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
-            </Button>
-          </Tooltip>
+          {onEnterFullscreen && (
+            <Tooltip content="Fullscreen" delay={0}>
+              <Button
+                aria-label="Enter fullscreen"
+                variant="quiet"
+                shape="square"
+                size="sm"
+                className="size-7"
+                onPress={onEnterFullscreen}
+              >
+                <MaximizeIcon />
+              </Button>
+            </Tooltip>
+          )}
         </div>
       </div>
+    );
+  }
+
+  function PreviewFrame() {
+    return (
       <div
         className={cn(
           "size-full",
@@ -286,6 +282,161 @@ export function PreviewContent({
           )}
         />
       </div>
+    );
+  }
+
+  function PreviewPane({
+    showFullscreenAction,
+  }: {
+    showFullscreenAction?: boolean;
+  }) {
+    return (
+      <div className="bg-bg relative size-full overflow-hidden border">
+        <PreviewToolbar
+          onToggleDevice={() => setWidth(isMobile ? 768 : 430)}
+          onOpenNewTab={() => {}}
+          onEnterFullscreen={
+            showFullscreenAction ? () => setIsFullscreen(true) : undefined
+          }
+        />
+        <PreviewFrame />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "bg-bg relative size-full overflow-hidden rounded-md border",
+        className,
+      )}
+    >
+      <PreviewToolbar
+        onToggleDevice={() => setWidth(isMobile ? 768 : 430)}
+        onOpenNewTab={() => {}}
+        onEnterFullscreen={() => setIsFullscreen(true)}
+      />
+      <PreviewFrame />
+
+      {/* Fullscreen via modal */}
+      <DialogRoot isOpen={isFullscreen} onOpenChange={setIsFullscreen}>
+        <Dialog
+          type="modal"
+          mobileType="modal"
+          modalProps={{
+            className:
+              "w-screen h-(--visual-viewport-height) max-w-none rounded-none border-0",
+          }}
+          className="p-0! h-full overflow-hidden rounded-none"
+          isDismissable
+        >
+          <div className="bg-bg relative size-full overflow-hidden border">
+            <div className="bg-bg-muted/50 flex items-center justify-between gap-2 border-b border-t-[inherit] px-1 py-1">
+              <div className="flex items-center gap-1">
+                {collapsible && (
+                  <Button
+                    aria-label="Collapse preview"
+                    variant="quiet"
+                    shape="square"
+                    size="sm"
+                    className="size-7"
+                    onPress={() => setOpen(false)}
+                  >
+                    <ChevronsRightIcon />
+                  </Button>
+                )}
+                <Separator orientation="vertical" className="h-4" />
+                <SelectRoot
+                  aria-label="Select block"
+                  onSelectionChange={(key) =>
+                    setCurrentBlockName(key as string)
+                  }
+                  selectedKey={currentBlockName}
+                >
+                  <Button
+                    variant="link"
+                    size="sm"
+                    suffix={<ChevronsUpDownIcon className="size-3.5!" />}
+                    className="text-fg-muted h-7 justify-center gap-1 rounded-sm px-2"
+                  >
+                    <SelectValue className="flex-0" />
+                  </Button>
+                  <Popover>
+                    <ListBox
+                      items={blocksCategories
+                        .filter((category) => category.slug !== "featured")
+                        .map((category) => ({
+                          key: category.slug,
+                          label: category.name,
+                          items: registryBlocks.filter((block) =>
+                            block?.categories?.includes(category.slug),
+                          ),
+                        }))}
+                    >
+                      {(section) => (
+                        <ListBoxSection
+                          id={section.key}
+                          title={section.label}
+                          items={section.items}
+                        >
+                          {(item) => (
+                            <ListBoxItem id={item.name}>
+                              {item.name}
+                            </ListBoxItem>
+                          )}
+                        </ListBoxSection>
+                      )}
+                    </ListBox>
+                  </Popover>
+                </SelectRoot>
+              </div>
+              <div className="flex gap-0.5">
+                <Tooltip content={isMobile ? "Mobile" : "Tablet"} delay={0}>
+                  <Button
+                    aria-label="Select view"
+                    variant="quiet"
+                    shape="square"
+                    size="sm"
+                    className="size-7"
+                    onPress={() => {
+                      setWidth(isMobile ? 768 : 430);
+                    }}
+                  >
+                    {isMobile ? <SmartphoneIcon /> : <TabletIcon />}
+                  </Button>
+                </Tooltip>
+                <Tooltip content="Open in new tab" delay={0}>
+                  <Button
+                    aria-label="Open in new tab"
+                    href={`/view/${username}/${styleName}/${currentBlockName}`}
+                    target="_blank"
+                    variant="quiet"
+                    shape="square"
+                    size="sm"
+                    className="size-7"
+                  >
+                    <ExternalLinkIcon />
+                  </Button>
+                </Tooltip>
+                <Tooltip content="Exit fullscreen" delay={0}>
+                  <Button
+                    aria-label="Exit fullscreen"
+                    variant="quiet"
+                    shape="square"
+                    size="sm"
+                    className="size-7"
+                    onPress={() => setIsFullscreen(false)}
+                  >
+                    <MinimizeIcon />
+                  </Button>
+                </Tooltip>
+              </div>
+            </div>
+            <PreviewFrame />
+          </div>
+        </Dialog>
+      </DialogRoot>
     </div>
   );
 }

--- a/www/components/preview.tsx
+++ b/www/components/preview.tsx
@@ -153,34 +153,24 @@ export function PreviewContent({
     setLoading(true);
   }, [currentBlockName]);
 
+  // CSS-only fullscreen overlay; no Fullscreen API
   React.useEffect(() => {
-    const handleFullscreenChange = () => {
-      const isActive = document.fullscreenElement === containerRef.current;
-      setIsFullscreen(isActive);
-    };
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    return () => {
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
-    };
-  }, []);
-
-  const toggleFullscreen = async () => {
-    try {
-      if (!isFullscreen) {
-        await containerRef.current?.requestFullscreen?.();
-      } else {
-        await document.exitFullscreen?.();
-      }
-    } catch (_) {
-      // ignore
+    const root = document.documentElement;
+    if (isFullscreen) {
+      root.classList.add("overflow-hidden");
+    } else {
+      root.classList.remove("overflow-hidden");
     }
-  };
+    return () => root.classList.remove("overflow-hidden");
+  }, [isFullscreen]);
 
   return (
     <div
       ref={containerRef}
       className={cn(
         "bg-bg size-full overflow-hidden rounded-md border",
+        isFullscreen &&
+          "fixed inset-0 z-50 rounded-none p-4 md:p-8 animate-in zoom-in-90",
         className,
       )}
     >
@@ -274,7 +264,7 @@ export function PreviewContent({
               shape="square"
               size="sm"
               className="size-7"
-              onPress={toggleFullscreen}
+              onPress={() => setIsFullscreen((v) => !v)}
             >
               {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
             </Button>

--- a/www/package.json
+++ b/www/package.json
@@ -65,7 +65,7 @@
     "react-stately": "catalog:ui",
     "remark-gfm": "^4.0.0",
     "sharp": "^0.33.2",
-    "shiki": "^3.8.1",
+    "shiki": "^3.12.2",
     "superjson": "2.2.2",
     "tailwind-merge": "catalog:ui",
     "tailwind-variants": "catalog:ui",


### PR DESCRIPTION
Add fullscreen toggle to the style editor preview toolbar.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ea5205a-dba6-48fd-8c28-776fa402b876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ea5205a-dba6-48fd-8c28-776fa402b876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

