### PR TITLE
fix(www): keep mobile docs search drawer above the iOS keyboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   www:
     dependencies:
       '@base-ui/react':
-        specifier: 1.4.1
-        version: 1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: 1.7.0
+        version: 1.7.0(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@dotui/colors':
         specifier: workspace:*
         version: link:../packages/colors
@@ -541,8 +541,8 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.4.1':
-    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -558,8 +558,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.2.8':
-    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': 19.2.2
       react: ^17 || ^18 || ^19
@@ -1104,20 +1104,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
-  '@floating-ui/react-dom@2.1.8':
-    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@fontsource-variable/geist@5.2.8':
     resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
@@ -5444,6 +5444,9 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  reselect@5.3.0:
+    resolution: {integrity: sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -6716,25 +6719,25 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
     optional: true
 
-  '@base-ui/react@1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@base-ui/react@1.7.0(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@floating-ui/utils': 0.2.11
+      '@base-ui/utils': 0.3.2(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@floating-ui/utils': 0.2.12
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       use-sync-external-store: 1.6.0(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.2
 
-  '@base-ui/utils@0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@base-ui/utils@0.3.2(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      reselect: 5.1.1
+      reselect: 5.3.0
       use-sync-external-store: 1.6.0(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.2
@@ -7051,22 +7054,22 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@floating-ui/core@1.7.5':
+  '@floating-ui/core@1.8.0':
     dependencies:
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/dom@1.7.6':
+  '@floating-ui/dom@1.8.0':
     dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  '@floating-ui/utils@0.2.11': {}
+  '@floating-ui/utils@0.2.12': {}
 
   '@fontsource-variable/geist@5.2.8': {}
 
@@ -11450,6 +11453,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   reselect@5.1.1: {}
+
+  reselect@5.3.0: {}
 
   resolve-from@4.0.0: {}
 

--- a/www/package.json
+++ b/www/package.json
@@ -16,7 +16,7 @@
     "probe:registry": "tsx scripts/registry-probe.ts"
   },
   "dependencies": {
-    "@base-ui/react": "1.4.1",
+    "@base-ui/react": "1.7.0",
     "@dotui/colors": "workspace:*",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/josefin-sans": "^5.2.8",

--- a/www/src/components/search-command.tsx
+++ b/www/src/components/search-command.tsx
@@ -3,7 +3,7 @@ import type * as PageTree from "fumadocs-core/page-tree"
 
 import { Responsive } from "@/registry/lib/responsive"
 import { Dialog, DialogContent } from "@/registry/ui/dialog"
-import { Drawer } from "@/registry/ui/drawer"
+import { Drawer, DrawerHandle } from "@/registry/ui/drawer"
 import {
   ModalBackdrop,
   ModalOverlay,
@@ -90,7 +90,7 @@ export function SearchCommand({
           const content = (
             <DialogContent
               aria-label="Search documentation"
-              className="flex flex-col gap-0 overflow-hidden p-0!"
+              className="flex flex-col gap-0 overflow-hidden p-0! max-md:min-h-0 max-md:flex-1"
             >
               {SearchDialog && (
                 <SearchDialog items={items} onClose={() => setIsOpen(false)} />
@@ -98,8 +98,15 @@ export function SearchCommand({
             </DialogContent>
           )
           return isMobile ? (
-            // Match the desktop modal's raised surface.
-            <Drawer className="bg-(--neutral-100)">{content}</Drawer>
+            // Match the desktop modal's raised surface. Near-full-height sheet
+            // (mirrors base-ui.com's mobile search): the input sits at the top,
+            // structurally clear of the iOS keyboard, and the results list
+            // flexes below it. The drawer's keyboard inset keeps the list's
+            // bottom above the keyboard.
+            <Drawer className="h-[calc(100dvh_-_3rem_+_var(--drawer-bleed))] bg-(--neutral-100)">
+              <DrawerHandle />
+              {content}
+            </Drawer>
           ) : (
             // Composed (not <Modal>) so the panel AND backdrop appear
             // instantly — duration-0 on both. Mirror shadcn.com: max-w-lg

--- a/www/src/components/search-dialog.tsx
+++ b/www/src/components/search-dialog.tsx
@@ -181,7 +181,11 @@ export default function SearchDialog({
     <Autocomplete inputValue={search} onInputChange={setSearch}>
       <div
         data-command=""
-        className={commandStyles({ className: "gap-0 overflow-y-hidden p-0" })}
+        className={commandStyles({
+          // On mobile the dialog fills a near-full-height drawer, so the
+          // command column flexes instead of sizing to its content.
+          className: "gap-0 overflow-y-hidden p-0 max-md:min-h-0 max-md:grow",
+        })}
       >
         <SearchField autoFocus aria-label="Search" className="px-1.5 pt-1.5">
           {/* Radius stays concentric with the modal (2xl − 6px inset); the
@@ -202,7 +206,7 @@ export default function SearchDialog({
               it rather than on the wrapper. */}
         <MenuContent
           aria-label="Search results"
-          className="max-h-80 overflow-y-auto p-1.5 pt-3 **:data-menu-item:py-2"
+          className="max-h-80 overflow-y-auto p-1.5 pt-3 **:data-menu-item:py-2 max-md:max-h-none max-md:min-h-0 max-md:grow"
           onAction={onClose}
           renderEmptyState={() => (
             <div className="py-8 text-center text-sm text-fg-muted">

--- a/www/src/modules/docs/references/generated/drawer-indent-background.json
+++ b/www/src/modules/docs/references/generated/drawer-indent-background.json
@@ -22,7 +22,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
+                  "id": "@base-ui/react/drawer/indent-background/DrawerIndentBackground.d.mts:DrawerIndentBackgroundState",
                   "name": "DrawerIndentBackgroundState"
                 },
                 "optional": false,
@@ -72,7 +72,7 @@
               },
               {
                 "type": "link",
-                "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
+                "id": "@base-ui/react/drawer/indent-background/DrawerIndentBackground.d.mts:DrawerIndentBackgroundState",
                 "name": "DrawerIndentBackgroundState"
               }
             ]
@@ -102,7 +102,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
+                  "id": "@base-ui/react/drawer/indent-background/DrawerIndentBackground.d.mts:DrawerIndentBackgroundState",
                   "name": "DrawerIndentBackgroundState"
                 },
                 "optional": false,
@@ -129,9 +129,9 @@
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState": {
+    "@base-ui/react/drawer/indent-background/DrawerIndentBackground.d.mts:DrawerIndentBackgroundState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
+      "id": "@base-ui/react/drawer/indent-background/DrawerIndentBackground.d.mts:DrawerIndentBackgroundState",
       "name": "DrawerIndentBackgroundState",
       "extends": [],
       "properties": {

--- a/www/src/modules/docs/references/generated/drawer-indent.json
+++ b/www/src/modules/docs/references/generated/drawer-indent.json
@@ -22,7 +22,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
+                  "id": "@base-ui/react/drawer/indent/DrawerIndent.d.mts:DrawerIndentState",
                   "name": "DrawerIndentState"
                 },
                 "optional": false,
@@ -72,7 +72,7 @@
               },
               {
                 "type": "link",
-                "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
+                "id": "@base-ui/react/drawer/indent/DrawerIndent.d.mts:DrawerIndentState",
                 "name": "DrawerIndentState"
               }
             ]
@@ -102,7 +102,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
+                  "id": "@base-ui/react/drawer/indent/DrawerIndent.d.mts:DrawerIndentState",
                   "name": "DrawerIndentState"
                 },
                 "optional": false,
@@ -129,9 +129,9 @@
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState": {
+    "@base-ui/react/drawer/indent/DrawerIndent.d.mts:DrawerIndentState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
+      "id": "@base-ui/react/drawer/indent/DrawerIndent.d.mts:DrawerIndentState",
       "name": "DrawerIndentState",
       "extends": [],
       "properties": {

--- a/www/src/modules/docs/references/generated/drawer-swipe-area.json
+++ b/www/src/modules/docs/references/generated/drawer-swipe-area.json
@@ -22,7 +22,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
+                  "id": "@base-ui/react/drawer/swipe-area/DrawerSwipeArea.d.mts:DrawerSwipeAreaState",
                   "name": "DrawerSwipeAreaState"
                 },
                 "optional": false,
@@ -81,7 +81,7 @@
               },
               {
                 "type": "link",
-                "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
+                "id": "@base-ui/react/drawer/swipe-area/DrawerSwipeArea.d.mts:DrawerSwipeAreaState",
                 "name": "DrawerSwipeAreaState"
               }
             ]
@@ -111,7 +111,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
+                  "id": "@base-ui/react/drawer/swipe-area/DrawerSwipeArea.d.mts:DrawerSwipeAreaState",
                   "name": "DrawerSwipeAreaState"
                 },
                 "optional": false,
@@ -147,9 +147,9 @@
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState": {
+    "@base-ui/react/drawer/swipe-area/DrawerSwipeArea.d.mts:DrawerSwipeAreaState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
+      "id": "@base-ui/react/drawer/swipe-area/DrawerSwipeArea.d.mts:DrawerSwipeAreaState",
       "name": "DrawerSwipeAreaState",
       "extends": [],
       "properties": {

--- a/www/src/modules/docs/references/generated/otp-field-separator.json
+++ b/www/src/modules/docs/references/generated/otp-field-separator.json
@@ -22,7 +22,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
+                  "id": "@base-ui/react/separator/Separator.d.mts:SeparatorState",
                   "name": "SeparatorState"
                 },
                 "optional": false,
@@ -82,7 +82,7 @@
               },
               {
                 "type": "link",
-                "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
+                "id": "@base-ui/react/separator/Separator.d.mts:SeparatorState",
                 "name": "SeparatorState"
               }
             ]
@@ -112,7 +112,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
+                  "id": "@base-ui/react/separator/Separator.d.mts:SeparatorState",
                   "name": "SeparatorState"
                 },
                 "optional": false,
@@ -139,9 +139,9 @@
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState": {
+    "@base-ui/react/separator/Separator.d.mts:SeparatorState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
+      "id": "@base-ui/react/separator/Separator.d.mts:SeparatorState",
       "name": "SeparatorState",
       "extends": [],
       "properties": {

--- a/www/src/modules/docs/references/generated/otp-field.json
+++ b/www/src/modules/docs/references/generated/otp-field.json
@@ -97,7 +97,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
+                  "id": "@base-ui/react/otp-field/root/OTPFieldRoot.d.mts:OTPFieldRootState",
                   "name": "OTPFieldRootState"
                 },
                 "optional": false,
@@ -212,6 +212,31 @@
       },
       "description": "Identifies the field when a form is submitted."
     },
+    "normalizeValue": {
+      "type": "((value: string) => string)",
+      "detailedType": "((value: string) => string) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "value",
+            "value": {
+              "type": "link",
+              "id": "string",
+              "name": "string"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "string"
+        },
+        "typeParameters": []
+      },
+      "description": "Function that normalizes the OTP value after whitespace and `validationType` filtering.\nIt runs whenever OTP Field normalizes a value, including initial/default values, controlled\nvalues, and user edits.\n\nThe returned value is filtered by `validationType` again, then clamped to `length`.\nIt should be idempotent because OTP Field may normalize the same value more than once while\nhandling edits, storing state, and rendering controlled or uncontrolled values. Non-idempotent\nnormalizers can compound across those normalization passes. Characters rejected while\nnormalizing typed or pasted text are reported through `onValueInvalid`."
+    },
     "onValueComplete": {
       "type": "((value: string, eventDetails: OTPFieldRootCompleteEventDetails) => void)",
       "detailedType": "| ((\n    value: string,\n    eventDetails: OTPFieldRootCompleteEventDetails,\n  ) => void)\n| undefined",
@@ -251,7 +276,7 @@
           }
         ]
       },
-      "description": "Callback function that is fired when the OTP value becomes complete.\n\nIt runs later than `onValueChange`, after the internal value update is applied.\n\nIf `autoSubmit` is enabled, it runs immediately before the owning form is submitted."
+      "description": "Callback function that is fired when the OTP value becomes complete, or when a complete value\nis pasted while the OTP is already complete.\n\nWhen the value changes, it runs later than `onValueChange`, after the internal value update is\napplied. If a complete pasted value matches the current value, `onValueChange` does not fire.\n\nIf `autoSubmit` is enabled, it runs immediately before the owning form is submitted."
     },
     "onValueInvalid": {
       "type": "((value: string, eventDetails: OTPFieldRootInvalidEventDetails) => void)",
@@ -292,7 +317,7 @@
           }
         ]
       },
-      "description": "Callback fired when entered text contains characters that are rejected by sanitization,\nbefore the OTP value updates.\n\nThe `value` argument is the attempted user-entered string before sanitization."
+      "description": "Callback fired when entered text contains characters that are rejected by validation or\nnormalization before the OTP value updates.\n\nThe `value` argument is the attempted user-entered string before normalization."
     },
     "render": {
       "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, OTPFieldRootState>",
@@ -320,7 +345,7 @@
               },
               {
                 "type": "link",
-                "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
+                "id": "@base-ui/react/otp-field/root/OTPFieldRoot.d.mts:OTPFieldRootState",
                 "name": "OTPFieldRootState"
               }
             ]
@@ -328,31 +353,6 @@
         ]
       },
       "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
-    },
-    "sanitizeValue": {
-      "type": "((value: string) => string)",
-      "detailedType": "((value: string) => string) | undefined",
-      "typeAst": {
-        "type": "function",
-        "parameters": [
-          {
-            "type": "parameter",
-            "name": "value",
-            "value": {
-              "type": "link",
-              "id": "string",
-              "name": "string"
-            },
-            "optional": false,
-            "rest": false
-          }
-        ],
-        "return": {
-          "type": "string"
-        },
-        "typeParameters": []
-      },
-      "description": "Function for custom sanitization when `validationType` is set to `'none'`.\nThis function runs before updating the OTP value from user interactions."
     },
     "style": {
       "type": "CSSProperties | ((state: OTPFieldRootState) => CSSProperties | undefined)",
@@ -375,7 +375,7 @@
                 "name": "state",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
+                  "id": "@base-ui/react/otp-field/root/OTPFieldRoot.d.mts:OTPFieldRootState",
                   "name": "OTPFieldRootState"
                 },
                 "optional": false,
@@ -420,14 +420,14 @@
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState": {
+    "@base-ui/react/otp-field/root/OTPFieldRoot.d.mts:OTPFieldRootState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
+      "id": "@base-ui/react/otp-field/root/OTPFieldRoot.d.mts:OTPFieldRootState",
       "name": "OTPFieldRootState",
       "extends": [
         {
           "type": "link",
-          "id": "@base-ui/react/esm/field/root/FieldRoot.d.ts:FieldRootState",
+          "id": "@base-ui/react/field/root/FieldRoot.d.mts:FieldRootState",
           "name": "FieldRootState"
         }
       ],

--- a/www/src/registry/ui/drawer/base.tsx
+++ b/www/src/registry/ui/drawer/base.tsx
@@ -131,38 +131,47 @@ function Drawer({
         }}
         swipeDirection={swipeDirectionMap[placement]}
       >
-        <DrawerPrimitive.Portal>
-          <ClearPressResponder>
-            <div className={overlay()}>
-              <DrawerPrimitive.Backdrop className={backdrop()} />
-              <DrawerPrimitive.Viewport className={viewport({ placement })}>
-                <DrawerPrimitive.Popup
-                  data-base-ui-swipe-ignore={swipeToDismiss ? undefined : ""}
-                  initialFocus={() => getInitialFocusTarget(popupRef.current)}
-                  className={(state) =>
-                    popup({
-                      placement,
-                      className: resolveClassName(className, state),
-                    })
-                  }
-                  render={(renderProps) => {
-                    const presentationProps = stripPopupDialogProps(renderProps)
+        {/* Keyboard-aware focus/scroll handling: publishes --drawer-keyboard-inset
+            on the viewport while the software keyboard is open. */}
+        <DrawerPrimitive.VirtualKeyboardProvider>
+          <DrawerPrimitive.Portal>
+            <ClearPressResponder>
+              <div className={overlay()}>
+                <DrawerPrimitive.Backdrop className={backdrop()} />
+                <DrawerPrimitive.Viewport className={viewport({ placement })}>
+                  <DrawerPrimitive.Popup
+                    data-base-ui-swipe-ignore={swipeToDismiss ? undefined : ""}
+                    initialFocus={() => getInitialFocusTarget(popupRef.current)}
+                    className={(state) =>
+                      popup({
+                        placement,
+                        className: resolveClassName(className, state),
+                      })
+                    }
+                    render={(renderProps) => {
+                      const presentationProps =
+                        stripPopupDialogProps(renderProps)
 
-                    return <div {...presentationProps} />
-                  }}
-                  ref={popupRef}
-                  style={style}
-                >
-                  <OverlayTriggerStateContext.Provider value={state}>
-                    {isDismissable && <DismissButton onDismiss={state.close} />}
-                    {children}
-                    {isDismissable && <DismissButton onDismiss={state.close} />}
-                  </OverlayTriggerStateContext.Provider>
-                </DrawerPrimitive.Popup>
-              </DrawerPrimitive.Viewport>
-            </div>
-          </ClearPressResponder>
-        </DrawerPrimitive.Portal>
+                      return <div {...presentationProps} />
+                    }}
+                    ref={popupRef}
+                    style={style}
+                  >
+                    <OverlayTriggerStateContext.Provider value={state}>
+                      {isDismissable && (
+                        <DismissButton onDismiss={state.close} />
+                      )}
+                      {children}
+                      {isDismissable && (
+                        <DismissButton onDismiss={state.close} />
+                      )}
+                    </OverlayTriggerStateContext.Provider>
+                  </DrawerPrimitive.Popup>
+                </DrawerPrimitive.Viewport>
+              </div>
+            </ClearPressResponder>
+          </DrawerPrimitive.Portal>
+        </DrawerPrimitive.VirtualKeyboardProvider>
       </DrawerPrimitive.Root>
     </DrawerPlacementContext.Provider>
   )

--- a/www/src/registry/ui/drawer/styles.ts
+++ b/www/src/registry/ui/drawer/styles.ts
@@ -31,7 +31,7 @@ const { useStyles, styles } = createStyles(drawerMeta, {
         bottom: {
           viewport: "grid grid-rows-[1fr_auto] overflow-visible pt-12",
           popup:
-            "row-start-2 [margin-bottom:calc(0px_-_var(--drawer-bleed))] max-h-[calc(100dvh_-_3rem_+_var(--drawer-bleed))] min-h-20 w-full [transform-origin:50%_100%] [transform:translateY(var(--drawer-swipe-movement-y,0px))] rounded-t-xl border-b-0 pb-[calc(env(safe-area-inset-bottom,0px)_+_var(--drawer-bleed))] data-[ending-style]:[transform:translateY(100%)] data-[nested-drawer-open]:[height:var(--drawer-frontmost-height,var(--drawer-height,auto))] data-[nested-drawer-open]:[transform:translateY(calc(var(--drawer-swipe-movement-y,0px)_-_var(--drawer-stack-offset)_-_(var(--drawer-shrink)_*_var(--drawer-frontmost-height,var(--drawer-height,0px)))))_scale(var(--drawer-scale))] data-[starting-style]:[transform:translateY(100%)]",
+            "row-start-2 [margin-bottom:calc(0px_-_var(--drawer-bleed))] max-h-[calc(100dvh_-_3rem_+_var(--drawer-bleed))] min-h-20 w-full [transform-origin:50%_100%] [transform:translateY(var(--drawer-swipe-movement-y,0px))] rounded-t-xl border-b-0 pb-[calc(env(safe-area-inset-bottom,0px)_+_var(--drawer-bleed)_+_var(--drawer-keyboard-inset,0px))] data-[ending-style]:[transform:translateY(100%)] data-[nested-drawer-open]:[height:var(--drawer-frontmost-height,var(--drawer-height,auto))] data-[nested-drawer-open]:[transform:translateY(calc(var(--drawer-swipe-movement-y,0px)_-_var(--drawer-stack-offset)_-_(var(--drawer-shrink)_*_var(--drawer-frontmost-height,var(--drawer-height,0px)))))_scale(var(--drawer-scale))] data-[starting-style]:[transform:translateY(100%)]",
           swipeArea: "inset-x-0 bottom-0 h-8",
         },
         left: {

--- a/www/src/registry/ui/otp-field/base.tsx
+++ b/www/src/registry/ui/otp-field/base.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { OTPFieldPreview as OTPFieldPrimitive } from "@base-ui/react/otp-field"
+import { OTPField as OTPFieldPrimitive } from "@base-ui/react/otp-field"
 import { composeRenderProps } from "react-aria-components/composeRenderProps"
 import * as FieldErrorPrimitive from "react-aria-components/FieldError"
 import * as InputPrimitive from "react-aria-components/Input"

--- a/www/src/registry/ui/otp-field/types.ts
+++ b/www/src/registry/ui/otp-field/types.ts
@@ -1,5 +1,5 @@
 import type * as React from "react"
-import type { OTPFieldPreview as OTPFieldPrimitive } from "@base-ui/react/otp-field"
+import type { OTPField as OTPFieldPrimitive } from "@base-ui/react/otp-field"
 
 /**
  * An OTP field lets users enter a one-time passcode across multiple single-character inputs.


### PR DESCRIPTION
## Problem

On iPhone, opening the docs search on mobile pops the software keyboard over the bottom drawer — the sheet stays pinned to the layout viewport bottom (the iOS keyboard shrinks only the *visual* viewport; `dvh` ignores it by design) and the keyboard paints right over the content-sized sheet.

## Fix

Studied how base-ui.com's mobile search drawer handles this and adopted the same two-part approach:

**Registry drawer** (`ui/drawer`)
- Upgrade `@base-ui/react` 1.4.1 → 1.7.0 and wrap the drawer tree in `Drawer.VirtualKeyboardProvider` (shipped in 1.6.0): it measures the keyboard via `visualViewport`, publishes `--drawer-keyboard-inset` on the viewport, keeps the focused field scrolled into the visible band, and suppresses WebKit's focus-reveal scroll.
- Bottom-placement popup consumes the inset in its bottom padding (`safe-area + bleed + keyboard inset`), so any bottom drawer's content rises clear of the keyboard. The var falls back to `0px` when the keyboard is closed, and padding already sits in the popup's transition-property list, so the shift animates with the drawer's own curve.

**Docs search drawer** (www)
- The mobile sheet is now near-full-height with a drag handle and the search input at the top — structurally out of the keyboard's zone, mirroring base-ui.com — and the results list flexes below it (`max-md:` only; the desktop ⌘K modal is untouched).

Only breaking change in base-ui 1.5–1.7 is the OTP Field namespace rename (`OTPFieldPreview` → `OTPField`), applied.

## Verification

- iOS Simulator (iPhone 17 Pro, mobile Safari, software keyboard): drawer opens full-height, input stays visible above the keyboard, results list bottom is padded clear of it; typing filters + full-text results render.
- Desktop ⌘K modal verified unchanged.
- `pnpm check` · `pnpm typecheck` · `build:registry` · `build:references` all green.

## Suggested refactors

- The keyboard-inset consumption currently lives in the popup's bottom padding. If a future drawer needs a base-ui-style pinned footer instead, the inset var is already published — worth a docs demo (`virtual-keyboard-aware`) mirroring base-ui's when the drawer docs get their next pass.
