### PR TITLE
fix(www): make the preset codec canonical

### DIFF
--- a/www/src/modules/create/preset/codec.test.ts
+++ b/www/src/modules/create/preset/codec.test.ts
@@ -2,6 +2,7 @@ import { deflateRaw } from "pako"
 import { describe, expect, it } from "vitest"
 
 import { DEFAULT_COLOR_CONFIG, type ColorConfig } from "@/registry/theme"
+import { ORIGIN, PRESETS } from "@/modules/presets/presets-data"
 
 import { decodePreset, encodePreset } from "./codec"
 import { DEFAULTS } from "./defaults"
@@ -153,5 +154,32 @@ describe("preset codec — color recipe", () => {
     const decoded = decodePreset(encoded).color
     expect(decoded?.primary).toBeUndefined()
     expect(decoded?.seeds.accent).toBe("#ef4444")
+  })
+})
+
+describe("preset codec — canonical encoding", () => {
+  // /create seeds from a stored state via decode → encode on reload; a
+  // non-identity roundtrip makes a freshly applied preset look edited.
+  for (const preset of [ORIGIN, ...PRESETS]) {
+    it(`encode∘decode is byte-identity for the ${preset.name} preset`, () => {
+      const encoded = encodePreset(preset.designSystem)
+      if (encoded === undefined) return
+      expect(encodePreset(decodePreset(encoded))).toBe(encoded)
+    })
+  }
+
+  it("encodes the same system identically regardless of input key order", () => {
+    const a = encodePreset({
+      ...DEFAULTS,
+      tokens: { "--radius": "0.75rem", "--font-sans": "Inter" },
+      color: { ...DEFAULT_COLOR_CONFIG, primary: "accent", vividness: 1.2 },
+    })
+    const b = encodePreset({
+      ...DEFAULTS,
+      tokens: { "--font-sans": "Inter", "--radius": "0.75rem" },
+      color: { ...DEFAULT_COLOR_CONFIG, vividness: 1.2, primary: "accent" },
+    })
+    expect(a).toBeTypeOf("string")
+    expect(b).toBe(a)
   })
 })

--- a/www/src/modules/create/preset/codec.ts
+++ b/www/src/modules/create/preset/codec.ts
@@ -33,15 +33,17 @@ function fromBase64Url(str: string): Uint8Array {
 
 /* ------------------------------ diff helpers ------------------------------ */
 
-/** Remove entries that match defaults, returning only overrides. */
+/** Remove entries that match defaults, returning only overrides (sorted keys
+ *  so the encoding doesn't depend on input key order). */
 function diffRecords(
   current: Record<string, string>,
   defaults: Record<string, string>,
 ): Record<string, string> | undefined {
   const result: Record<string, string> = {}
   let hasEntries = false
-  for (const [key, value] of Object.entries(current)) {
-    if (value !== defaults[key]) {
+  for (const key of Object.keys(current).sort()) {
+    const value = current[key]
+    if (value !== undefined && value !== defaults[key]) {
       result[key] = value
       hasEntries = true
     }
@@ -55,8 +57,8 @@ function diffNestedRecords(
 ): Record<string, Record<string, string>> | undefined {
   const result: Record<string, Record<string, string>> = {}
   let hasEntries = false
-  for (const [outer, inner] of Object.entries(current)) {
-    const innerDiff = diffRecords(inner, defaults[outer] ?? {})
+  for (const outer of Object.keys(current).sort()) {
+    const innerDiff = diffRecords(current[outer] ?? {}, defaults[outer] ?? {})
     if (innerDiff) {
       result[outer] = innerDiff
       hasEntries = true
@@ -77,11 +79,40 @@ function mergeNested(
   return merged
 }
 
+/* ----------------------------- sanitize helpers ----------------------------- */
+
+/**
+ * Migrate a color recipe to `ColorConfig` v2 — v1 shapes map onto the nearest
+ * v2 axes, garbage falls back to the default (never throws). A result equal to
+ * the default becomes `undefined` so it encodes to nothing.
+ */
+function sanitizeColor(
+  color: ColorConfig | undefined,
+): ColorConfig | undefined {
+  if (!color) return undefined
+  const migrated = migrateColorConfig(color)
+  return JSON.stringify(migrated) === JSON.stringify(DEFAULT_COLOR_CONFIG)
+    ? undefined
+    : migrated
+}
+
+/** Unknown/garbage library names sanitize to the default (lucide → `undefined`). */
+function sanitizeIcons(
+  icons: IconLibraryName | undefined,
+): IconLibraryName | undefined {
+  if (!icons || icons === "lucide") return undefined
+  return iconLibraries.some((lib) => lib.name === icons) ? icons : undefined
+}
+
 /* --------------------------------- encode --------------------------------- */
 
 /**
  * Encode a DesignSystem into a compact URL-safe string.
  * Returns `undefined` when all values match defaults (no preset needed).
+ *
+ * Canonical: sanitizers rebuild recipes in a fixed key order and diffs emit
+ * sorted keys, so encode∘decode is byte-identity regardless of how the input
+ * was constructed.
  */
 export function encodePreset(ds: DesignSystem): string | undefined {
   const compact: DesignSystemState = {}
@@ -98,20 +129,18 @@ export function encodePreset(ds: DesignSystem): string | undefined {
   if (ds.density !== DEFAULTS.density) compact.d = ds.density
 
   // Store the whole (small) color recipe only when it differs from the default palette.
-  if (
-    ds.color &&
-    JSON.stringify(ds.color) !== JSON.stringify(DEFAULT_COLOR_CONFIG)
-  )
-    compact.c = ds.color
+  const color = sanitizeColor(ds.color)
+  if (color) compact.c = color
 
   // Store the whole (small) code-options recipe only when it differs from the default style.
-  if (
-    ds.codeOptions &&
-    JSON.stringify(ds.codeOptions) !== JSON.stringify(DEFAULT_CODE_OPTIONS)
-  )
-    compact.o = ds.codeOptions
+  if (ds.codeOptions) {
+    const codeOptions = sanitizeCodeOptions(ds.codeOptions)
+    if (JSON.stringify(codeOptions) !== JSON.stringify(DEFAULT_CODE_OPTIONS))
+      compact.o = codeOptions
+  }
 
-  if (ds.icons && ds.icons !== "lucide") compact.i = ds.icons
+  const icons = sanitizeIcons(ds.icons)
+  if (icons) compact.i = icons
 
   if (
     !compact.p &&
@@ -129,29 +158,6 @@ export function encodePreset(ds: DesignSystem): string | undefined {
 }
 
 /* --------------------------------- decode --------------------------------- */
-
-/**
- * Migrate a decoded color recipe to `ColorConfig` v2 — v1 shapes map onto the
- * nearest v2 axes, garbage falls back to the default (never throws). A result
- * equal to the default decodes as `undefined` so it re-encodes to nothing.
- */
-function sanitizeColor(
-  color: ColorConfig | undefined,
-): ColorConfig | undefined {
-  if (!color) return undefined
-  const migrated = migrateColorConfig(color)
-  return JSON.stringify(migrated) === JSON.stringify(DEFAULT_COLOR_CONFIG)
-    ? undefined
-    : migrated
-}
-
-/** Unknown/garbage library names decode as the default (lucide → `undefined`). */
-function sanitizeIcons(
-  icons: IconLibraryName | undefined,
-): IconLibraryName | undefined {
-  if (!icons || icons === "lucide") return undefined
-  return iconLibraries.some((lib) => lib.name === icons) ? icons : undefined
-}
 
 /**
  * Decode a preset string back into a full DesignSystem.

--- a/www/src/modules/panel-lab/create.tsx
+++ b/www/src/modules/panel-lab/create.tsx
@@ -33,6 +33,8 @@ import { PanelB } from "./variants/panel-b"
 
 const routeApi = getRouteApi("/_app/create")
 
+/* The codec is canonical (encode∘decode = identity), but states from the URL
+   or storage may predate it — one roundtrip normalizes those. */
 function canon(state: string): string {
   if (!state) return ""
   return encodePreset(decodePreset(state)) ?? ""
@@ -40,7 +42,7 @@ function canon(state: string): string {
 
 /* Origin is the panel's baseline: what first-time users start on, what the
    global reset returns to, and what the modified dot diffs against. */
-const ORIGIN_CANON = canon(encodePreset(ORIGIN.designSystem) ?? "")
+const ORIGIN_CANON = encodePreset(ORIGIN.designSystem) ?? ""
 
 export function LabCreatePanel({ className }: { className?: string }) {
   const lab = useLab()
@@ -68,12 +70,8 @@ export function LabCreatePanel({ className }: { className?: string }) {
 
   // Built-in presets are re-loadable from the gallery, so a freshly applied one
   // isn't unsaved work — only edits past it (or past a saved snapshot) are.
-  // encode∘decode isn't byte-identical (a reload's seeded state re-encodes
-  // slightly differently), so states compare in canonical form — one roundtrip
-  // reaches a fixed point.
   const builtInStates = useMemo(
-    () =>
-      new Set(PRESETS.map((p) => canon(encodePreset(p.designSystem) ?? ""))),
+    () => new Set(PRESETS.map((p) => encodePreset(p.designSystem) ?? "")),
     [],
   )
   const currentState = preset ?? ""


### PR DESCRIPTION
## Summary

- `encodePreset(decodePreset(x)) !== x` for 3 built-in presets (Claude, Linear, GitHub): decode runs the color recipe through `migrateColorConfig`, which rebuilds it in a fixed key order, while encode stored the recipe as constructed — `primary`/`background` swapped positions, the deflated bytes differed, and a reload's seeded state made a freshly applied preset look edited.
- Encode now stores sanitized values (`migrateColorConfig` for color, `sanitizeCodeOptions` for code options, `sanitizeIcons` for icons) and the diff helpers emit sorted keys, so encoding is independent of how the input was constructed (the defaults-merge in decode could also reorder `componentParams`/token keys).
- New tests: `encode∘decode` byte-identity for Origin + every `PRESETS` entry (failed for the 3 presets above before the fix), plus a key-order-independence case.
- `panel-lab/create.tsx` drops the `canon()` roundtrip for in-memory encodes (`ORIGIN_CANON`, built-in preset states); it stays only for URL/storage states, which may predate the canonical encoding.

Reviewer note: `save-preset-dialog.tsx` still compares a saved state raw against a fresh encode, so a legacy-encoded save can show dirty once until re-saved. Left alone — it self-heals, and the old panel (`create/panel/control-panel.tsx`) is unmounted.