### PR TITLE
fix(www): make command style-1 search field radius concentric

### DIFF
--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -21,7 +21,7 @@ const { useStyles, styles } = createStyles(commandMeta, {
     style: {
       1: {
         base: [
-          "p-1.5 **:data-listbox:overflow-visible **:data-listbox:p-0 **:data-search-field:pb-0 **:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-sm",
+          "p-1.5 **:data-listbox:overflow-visible **:data-listbox:p-0 **:data-search-field:pb-0 **:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
         ],
       },
       2: {


### PR DESCRIPTION
Command style 1 hardcoded `rounded-sm` (5px) on the search field's input group, which sat visibly squarer than the panel-radius shells it lives in (Card/Modal/Popover all round at `--radius-panel` = 15px). It also overrode the input's own `--radius-control` default and tracked the global `--radius` scale instead of the panel role, so themes moving `--radius-panel` independently would drift further.

Replaced it with the concentric value `calc(var(--radius-panel) - --spacing(1.5))`, matching style 1's `p-1.5` inset — 9px inside a 15px shell.

Verified on the landing `CommandMenu` showcase card: input group renders at 9px inside the 15px card radius. Styles 2 and 3 are frameless and unaffected.