### PR TITLE
feat(www): restyle settings and notifications blocks as opened modal cards

### DIFF
--- a/www/src/modules/create/preview/blocks/notifications-center.tsx
+++ b/www/src/modules/create/preview/blocks/notifications-center.tsx
@@ -20,6 +20,7 @@ import {
   TriangleAlertIcon,
   Users2Icon,
   VolumeOffIcon,
+  XIcon,
   ZapIcon,
 } from "@/registry/icons"
 import { cn } from "@/registry/lib/utils"
@@ -647,14 +648,17 @@ export default function NotificationsCenter() {
   }
 
   return (
-    <div className="min-h-screen bg-bg text-fg">
+    // Same fake-modal shell as the settings block — the backdrop and card
+    // reuse the Modal style's global vars so the fake tracks the axis.
+    <div className="relative flex h-svh items-center justify-center bg-bg p-4 text-fg sm:p-8">
+      <div className="absolute inset-0 bg-overlay/(--modal-backdrop-opacity) backdrop-blur-(--modal-backdrop-blur)" />
       <Tabs
         selectedKey={tab}
         onSelectionChange={(key) => setTab(key as TabId)}
-        className="flex min-h-screen flex-col gap-0"
+        className="relative flex h-full max-h-[46rem] w-full max-w-5xl flex-col gap-0 overflow-hidden rounded-(--modal-radius) border border-border-elevated bg-(--modal-background) shadow-[var(--shadow-overlay,var(--shadow-lg))]"
       >
-        <header className="sticky top-0 z-20 border-b bg-bg/90 backdrop-blur">
-          <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 pt-4 sm:px-6">
+        <header className="shrink-0 border-b">
+          <div className="flex w-full flex-col gap-3 px-4 pt-4 sm:px-6">
             <div className="flex items-center gap-3">
               <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary text-fg-on-primary">
                 <BellIcon className="size-4" />
@@ -775,6 +779,20 @@ export default function NotificationsCenter() {
                     </MenuContent>
                   </Popover>
                 </Menu>
+
+                <Separator orientation="vertical" className="h-5" />
+
+                <Tooltip>
+                  <Button
+                    size="sm"
+                    variant="quiet"
+                    isIconOnly
+                    aria-label="Close notifications"
+                  >
+                    <XIcon />
+                  </Button>
+                  <TooltipContent>Close</TooltipContent>
+                </Tooltip>
               </div>
             </div>
 
@@ -804,7 +822,7 @@ export default function NotificationsCenter() {
           </div>
         </header>
 
-        <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 sm:px-6">
+        <main className="min-h-0 w-full flex-1 overflow-y-auto px-4 py-6 sm:px-6">
           <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
             <div className="min-w-0">
               {TABS.map((t) => (

--- a/www/src/modules/create/preview/blocks/notifications-center.tsx
+++ b/www/src/modules/create/preview/blocks/notifications-center.tsx
@@ -380,10 +380,8 @@ function NotificationRow({
 
   return (
     <li
-      className={cn(
-        "group relative flex gap-3 rounded-lg border border-transparent px-2 py-3 transition-colors hover:border-border-muted hover:bg-card sm:px-3",
-        item.unread && "bg-card",
-      )}
+      // Quiet-button hover — flat rows, no card background.
+      className="group relative flex gap-3 rounded-lg px-2 py-3 transition-colors hover:bg-inverse/10 sm:px-3"
     >
       <span
         aria-hidden
@@ -660,9 +658,6 @@ export default function NotificationsCenter() {
         <header className="shrink-0 border-b">
           <div className="flex w-full flex-col gap-3 px-4 pt-4 sm:px-6">
             <div className="flex items-center gap-3">
-              <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary text-fg-on-primary">
-                <BellIcon className="size-4" />
-              </span>
               <div className="flex min-w-0 flex-col">
                 <h1 className="truncate font-heading text-lg font-semibold tracking-tight">
                   Notifications

--- a/www/src/modules/create/preview/blocks/settings.tsx
+++ b/www/src/modules/create/preview/blocks/settings.tsx
@@ -18,6 +18,7 @@ import {
   TriangleAlertIcon,
   UploadIcon,
   UserIcon,
+  XIcon,
 } from "@/registry/icons"
 import { cn } from "@/registry/lib/utils"
 import {
@@ -978,53 +979,70 @@ export default function SettingsBlock() {
   const [isDirty, setIsDirty] = useState(false)
 
   return (
-    <SidebarProvider className="min-h-screen bg-bg text-fg">
-      <SettingsSidebar section={section} onSectionChange={setSection} />
-      <SidebarInset>
-        {/* Mobile only — the sidebar is a drawer there and needs its trigger. */}
-        <header className="flex h-12 items-center gap-2 border-b px-3 md:hidden">
-          <SidebarTrigger />
-          <span className="font-medium">Settings</span>
-        </header>
+    // Looks like an opened settings modal but is a plain card — the backdrop
+    // and card reuse the Modal style's global vars so the fake tracks the axis.
+    <div className="relative flex min-h-screen items-center justify-center bg-bg p-4 text-fg sm:p-8">
+      <div className="absolute inset-0 bg-overlay/(--modal-backdrop-opacity) backdrop-blur-(--modal-backdrop-blur)" />
+      <SidebarProvider className="relative h-[min(46rem,calc(100svh-3rem))] min-h-0 w-full max-w-5xl overflow-hidden rounded-(--modal-radius) border border-border-elevated bg-(--modal-background) shadow-[var(--shadow-overlay,var(--shadow-lg))]">
+        <SettingsSidebar section={section} onSectionChange={setSection} />
+        <Tooltip>
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            aria-label="Close settings"
+            className="absolute top-2 right-2 z-20"
+          >
+            <XIcon />
+          </Button>
+          <TooltipContent>Close</TooltipContent>
+        </Tooltip>
+        <SidebarInset className="min-w-0 overflow-y-auto bg-transparent">
+          {/* Mobile only — the sidebar is a drawer there and needs its trigger. */}
+          <header className="sticky top-0 z-10 flex h-12 shrink-0 items-center gap-2 border-b bg-(--modal-background) px-3 md:hidden">
+            <SidebarTrigger />
+            <span className="font-medium">Settings</span>
+          </header>
 
-        {/* Change events bubble, so one handler marks the whole page dirty. */}
-        <div onChange={() => setIsDirty(true)}>
-          <div className="mx-auto flex w-full max-w-3xl flex-col px-4 py-6 sm:px-8 sm:py-10">
-            <div className="flex min-w-0 flex-col gap-10 text-base">
-              {section === "account" && <AccountSection />}
-              {section === "notifications" && <NotificationsSection />}
-              {section === "appearance" && <AppearanceSection />}
-              {section === "connections" && <ConnectionsSection />}
-              {section === "security" && <SecuritySection />}
-            </div>
+          {/* Change events bubble, so one handler marks the whole page dirty. */}
+          <div onChange={() => setIsDirty(true)}>
+            <div className="mx-auto flex w-full max-w-3xl flex-col px-4 py-6 sm:px-8 sm:py-10">
+              <div className="flex min-w-0 flex-col gap-10 text-base">
+                {section === "account" && <AccountSection />}
+                {section === "notifications" && <NotificationsSection />}
+                {section === "appearance" && <AppearanceSection />}
+                {section === "connections" && <ConnectionsSection />}
+                {section === "security" && <SecuritySection />}
+              </div>
 
-            <div
-              className={cn(
-                "sticky bottom-4 z-10 mt-6 transition-opacity",
-                isDirty ? "opacity-100" : "pointer-events-none opacity-0",
-              )}
-            >
-              <div className="flex items-center justify-between gap-3 rounded-xl border bg-card p-3 shadow-lg">
-                <span className="min-w-0 truncate text-sm text-fg-muted">
-                  You have unsaved changes.
-                </span>
-                <div className="flex shrink-0 items-center gap-2">
-                  <Button size="sm" onPress={() => setIsDirty(false)}>
-                    Discard
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="primary"
-                    onPress={() => setIsDirty(false)}
-                  >
-                    Save changes
-                  </Button>
+              <div
+                className={cn(
+                  "sticky bottom-4 z-10 mt-6 transition-opacity",
+                  isDirty ? "opacity-100" : "pointer-events-none opacity-0",
+                )}
+              >
+                <div className="flex items-center justify-between gap-3 rounded-xl border bg-card p-3 shadow-lg">
+                  <span className="min-w-0 truncate text-sm text-fg-muted">
+                    You have unsaved changes.
+                  </span>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button size="sm" onPress={() => setIsDirty(false)}>
+                      Discard
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="primary"
+                      onPress={() => setIsDirty(false)}
+                    >
+                      Save changes
+                    </Button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+        </SidebarInset>
+      </SidebarProvider>
+    </div>
   )
 }

--- a/www/src/modules/create/preview/blocks/settings.tsx
+++ b/www/src/modules/create/preview/blocks/settings.tsx
@@ -981,9 +981,9 @@ export default function SettingsBlock() {
   return (
     // Looks like an opened settings modal but is a plain card — the backdrop
     // and card reuse the Modal style's global vars so the fake tracks the axis.
-    <div className="relative flex min-h-screen items-center justify-center bg-bg p-4 text-fg sm:p-8">
+    <div className="relative flex h-svh items-center justify-center bg-bg p-4 text-fg sm:p-8">
       <div className="absolute inset-0 bg-overlay/(--modal-backdrop-opacity) backdrop-blur-(--modal-backdrop-blur)" />
-      <SidebarProvider className="relative h-[min(46rem,calc(100svh-3rem))] min-h-0 w-full max-w-5xl overflow-hidden rounded-(--modal-radius) border border-border-elevated bg-(--modal-background) shadow-[var(--shadow-overlay,var(--shadow-lg))]">
+      <SidebarProvider className="relative h-full max-h-[46rem] min-h-0 w-full max-w-5xl overflow-hidden rounded-(--modal-radius) border border-border-elevated bg-(--modal-background) shadow-[var(--shadow-overlay,var(--shadow-lg))]">
         <SettingsSidebar section={section} onSectionChange={setSection} />
         <Tooltip>
           <Button


### PR DESCRIPTION
## What

The `/create` preview settings and notifications blocks now render as fake opened modals: the same designs inside, wrapped in a centered dialog-styled card over a dimmed backdrop, with a decorative close button.

## How

- The backdrop and card reuse the Modal style's global CSS vars (`--modal-backdrop-opacity`, `--modal-backdrop-blur`, `--modal-background`, `--modal-radius`, overlay shadow), so the fakes track the builder's modal axes without a real `<Modal>`.
- **Settings**: `SidebarProvider` itself becomes the card (it's the sidebar's `relative` positioning context); `SidebarInset` scrolls internally. The close X floats at the card's top-right; on mobile it sits in the sticky header row beside the sidebar trigger.
- **Notifications**: the `Tabs` wrapper becomes the card as a flex column — fixed header (with the close X appended to the action cluster after a separator), scrollable `main`.
- Both cards fill an exactly-viewport wrapper (`h-svh` + padding, card `h-full max-h-[46rem]`), so the page never overflows the preview iframe.

## Notes for review

- Verified at desktop and mobile widths: no page overflow in either axis, internal scrolling, the settings sticky "unsaved changes" bar, and the real delete-workspace modal stacking above the fake one.
- No registry changes, so no `__generated__` regeneration needed.