### PR TITLE
feat(www): navigate the /create preview in-iframe instead of remounting

### DIFF
--- a/www/src/modules/create/preset/iframe-sync.ts
+++ b/www/src/modules/create/preset/iframe-sync.ts
@@ -12,6 +12,8 @@ type ParentToIframeMessage =
   | { type: "design-system"; data: DesignSystem }
   | { type: "preview-mode"; mode: PreviewMode }
   | { type: "preview-ping" }
+  | { type: "preview-navigate"; slug: string }
+  | { type: "preview-prefetch"; slug: string }
   | { type: "inspector-mode"; enabled: boolean }
 
 type IframeToParentMessage =
@@ -39,6 +41,34 @@ export function sendPreviewMode(
   if (!iframe?.contentWindow) return
   iframe.contentWindow.postMessage(
     { type: "preview-mode", mode } satisfies ParentToIframeMessage,
+    "*",
+  )
+}
+
+/**
+ * Ask the iframe's SPA router to show another preview. Navigating inside the
+ * document — instead of remounting the iframe — keeps its module cache and
+ * design-system state alive, so revisited previews render instantly.
+ */
+export function sendPreviewNavigate(
+  iframe: HTMLIFrameElement | null,
+  slug: string,
+) {
+  if (!iframe?.contentWindow) return
+  iframe.contentWindow.postMessage(
+    { type: "preview-navigate", slug } satisfies ParentToIframeMessage,
+    "*",
+  )
+}
+
+/** Ask the iframe to warm a preview's chunk (e.g. on picker-item hover). */
+export function sendPreviewPrefetch(
+  iframe: HTMLIFrameElement | null,
+  slug: string,
+) {
+  if (!iframe?.contentWindow) return
+  iframe.contentWindow.postMessage(
+    { type: "preview-prefetch", slug } satisfies ParentToIframeMessage,
     "*",
   )
 }
@@ -94,6 +124,32 @@ export function useIframeMessageListener(
       if (event.data?.type === "design-system") {
         onMessageRef.current(event.data.data)
       }
+    }
+
+    window.addEventListener("message", handleMessage)
+    return () => window.removeEventListener("message", handleMessage)
+  }, [])
+}
+
+/** Inside the preview iframe: follow the parent's block switches and prefetch hints. */
+export function usePreviewNavigationMessages(handlers: {
+  onNavigate: (slug: string) => void
+  onPrefetch: (slug: string) => void
+}) {
+  const handlersRef = React.useRef(handlers)
+
+  React.useEffect(() => {
+    handlersRef.current = handlers
+  }, [handlers])
+
+  React.useEffect(() => {
+    if (!isInIframe()) return
+
+    const handleMessage = (event: MessageEvent) => {
+      const { type, slug } = event.data ?? {}
+      if (typeof slug !== "string") return
+      if (type === "preview-navigate") handlersRef.current.onNavigate(slug)
+      if (type === "preview-prefetch") handlersRef.current.onPrefetch(slug)
     }
 
     window.addEventListener("message", handleMessage)

--- a/www/src/modules/create/preset/index.ts
+++ b/www/src/modules/create/preset/index.ts
@@ -8,6 +8,8 @@ export {
   sendInspectorExit,
   sendInspectorMode,
   sendPreviewMode,
+  sendPreviewNavigate,
+  sendPreviewPrefetch,
   sendToIframe,
   useAnnouncePreviewReady,
   useIframeMessageListener,

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { getRouteApi } from "@tanstack/react-router"
 import {
   ChevronDownIcon,
@@ -39,6 +39,8 @@ import {
   pingIframe,
   sendInspectorMode,
   sendPreviewMode,
+  sendPreviewNavigate,
+  sendPreviewPrefetch,
   sendToIframe,
   useDesignSystem,
   useInspectorExitMessages,
@@ -159,38 +161,29 @@ export function PreviewPanel({
   // server can't know the client's stored theme (it always resolves "light"), so reading
   // it during render would mismatch the SSR'd toggle icon on hydration. Runs once — the
   // preview mode is toggled independently of the site theme afterwards.
-  const modeSeeded = useRef(false)
   useEffect(() => {
     setPreviewMode(resolvedTheme)
-    modeSeeded.current = true
     // oxlint-disable-next-line react/exhaustive-deps -- seed once from the site theme at open; preview mode is independent thereafter
   }, [])
 
-  // Bake the preset into the iframe src so the initial render has the right state.
-  // Only recompute when the previewed component changes (not on every param change)
-  // — further updates go through postMessage without reloading the iframe.
-  const iframeSrc = useMemo(() => {
+  // The iframe's document URL, fixed at mount — the preset is baked in so the
+  // initial render has the right state. Everything after goes over postMessage
+  // (preset / mode changes, and preview switches, which navigate the iframe's
+  // own SPA router), so the iframe never reloads.
+  const [iframeSrc] = useState(() => {
     const base = `/preview/${effectivePreview}`
-    const params = new URLSearchParams()
-    if (preset) params.set("preset", preset)
-    // Bake the current mode in so a remounted iframe first-paints in the
-    // previewed mode instead of flashing from its own stored theme. Skipped on
-    // the very first compute — previewMode hasn't seeded yet and the fresh
-    // iframe's stored theme already matches the site's.
-    if (modeSeeded.current) params.set("mode", previewMode)
-    const qs = params.toString()
-    return qs ? `${base}?${qs}` : base
-    // oxlint-disable-next-line react/exhaustive-deps -- keep live preset / mode changes on the postMessage channel to avoid iframe reloads
-  }, [effectivePreview])
+    return preset ? `${base}?${new URLSearchParams({ preset })}` : base
+  })
 
-  // The iframe remounts per previewed component (key below) — show the stage
-  // skeleton again until the new document signals it has rendered. The iframe's
-  // `load` event is too early (it fires before the SPA paints), so wait for the
-  // app's own `preview-ready` instead. On first load the iframe usually mounts
-  // before this server-rendered parent hydrates, so its unprompted announcement
-  // lands with no listener attached — poll until it answers rather than trusting
-  // that one message. Give up after PREVIEW_READY_TIMEOUT so a preview that
-  // never reports (an error page, say) reveals itself instead of hanging.
+  // Show the stage skeleton until the iframe's document signals it has rendered
+  // — initial boot only, since preview switches keep the document alive. The
+  // iframe's `load` event is too early (it fires before the SPA paints), so
+  // wait for the app's own `preview-ready` instead. On first load the iframe
+  // usually mounts before this server-rendered parent hydrates, so its
+  // unprompted announcement lands with no listener attached — poll until it
+  // answers rather than trusting that one message. Give up after
+  // PREVIEW_READY_TIMEOUT so a preview that never reports (an error page, say)
+  // reveals itself instead of hanging.
   useEffect(() => {
     setIsLoaded(false)
     const iframe = iframeRef.current
@@ -218,6 +211,27 @@ export function PreviewPanel({
       window.removeEventListener("message", onReady)
     }
   }, [iframeSrc])
+
+  // Preview switches navigate the iframe's SPA router instead of remounting the
+  // iframe — the current preview stays on screen until the next one commits, and
+  // revisited previews appear instantly from the document's module cache. Resent
+  // on load / ready: a switch made while the document is still booting would
+  // land before its message listener exists. (The iframe ignores same-slug sends.)
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+    const send = () => sendPreviewNavigate(iframe, effectivePreview)
+    if (iframe.contentWindow) send()
+    iframe.addEventListener("load", send)
+    const onReady = (event: MessageEvent) => {
+      if (event.data?.type === "preview-ready") send()
+    }
+    window.addEventListener("message", onReady)
+    return () => {
+      iframe.removeEventListener("load", send)
+      window.removeEventListener("message", onReady)
+    }
+  }, [effectivePreview])
 
   // Send the design system to the iframe on change, on load, and when the iframe signals it's
   // ready — its message listener can mount after the load event, racing the load-fired send.
@@ -318,6 +332,11 @@ export function PreviewPanel({
     : PREVIEW_ITEMS.slice(0, PREVIEW_ITEMS_COLLAPSED)
   const hiddenPreviewCount = PREVIEW_ITEMS.length - visiblePreviews.length
 
+  // Warm a preview's chunk inside the iframe while the pointer hovers its
+  // picker item, so the switch on click is instant.
+  const prefetchPreview = (slug: string) =>
+    sendPreviewPrefetch(iframeRef.current, slug)
+
   // Picker body shared by the desktop popover and the mobile drawer — only the
   // list's sizing differs between the two containers. Selection state comes
   // from the wrapping Select, so the ListBox carries no props of its own.
@@ -339,6 +358,7 @@ export function PreviewPanel({
               key={block.slug}
               id={block.slug}
               textValue={block.name}
+              onHoverStart={() => prefetchPreview(block.slug)}
             >
               <span className="truncate">{block.name}</span>
             </ListBoxItem>
@@ -354,7 +374,12 @@ export function PreviewPanel({
         <ListBoxSection>
           <ListBoxSectionHeader>Components</ListBoxSectionHeader>
           {ALL_COMPONENTS.map((comp) => (
-            <ListBoxItem key={comp.slug} id={comp.slug} textValue={comp.name}>
+            <ListBoxItem
+              key={comp.slug}
+              id={comp.slug}
+              textValue={comp.name}
+              onHoverStart={() => prefetchPreview(comp.slug)}
+            >
               <span className="truncate">{comp.name}</span>
             </ListBoxItem>
           ))}
@@ -388,7 +413,6 @@ export function PreviewPanel({
         <div className="flex h-full w-full">
           <iframe
             ref={iframeRef}
-            key={effectivePreview}
             src={iframeSrc}
             title="preview"
             className={cn(
@@ -637,9 +661,18 @@ export function PreviewPanel({
                 variant="quiet"
                 isIconOnly
                 className="rounded-full"
-                onPress={() =>
-                  window.open(iframeSrc, "_blank", "noopener,noreferrer")
-                }
+                onPress={() => {
+                  // Built at click time — the iframe src is frozen at mount, so
+                  // it no longer reflects the current preview or mode.
+                  const params = new URLSearchParams()
+                  if (preset) params.set("preset", preset)
+                  params.set("mode", previewMode)
+                  window.open(
+                    `/preview/${effectivePreview}?${params}`,
+                    "_blank",
+                    "noopener,noreferrer",
+                  )
+                }}
                 aria-label="Open preview in new tab"
               >
                 <ExternalLinkIcon />

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -75,11 +75,6 @@ const ALL_COMPONENTS = componentsData
 // Composed, real-world previews: the landing cards grid plus the page blocks.
 const PREVIEW_ITEMS = [{ slug: "cards", name: "Cards" }, ...AVAILABLE_BLOCKS]
 
-// How many previews the picker shows before "Show more".
-const PREVIEW_ITEMS_COLLAPSED = 4
-
-const SHOW_ALL_PREVIEWS_ID = "__show-all-previews"
-
 // Zoom magnifies the rendered iframe (CSS `zoom`, no reflow) — distinct from device
 // size, which reflows the content. Combined, they behave like a browser's device bar.
 const ZOOM_LEVELS = [0.5, 0.75, 1, 1.25, 1.5, 2]
@@ -120,11 +115,6 @@ export function PreviewPanel({
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
-  const [pickerQuery, setPickerQuery] = useState("")
-  const [showAllPreviews, setShowAllPreviews] = useState(false)
-  // Set when "Show more" is picked so the close the Select requests right
-  // after committing that selection can be swallowed.
-  const keepPickerOpen = useRef(false)
   const [inspecting, setInspecting] = useState(false)
   const [toolbarHidden, setToolbarHidden] = useState(false)
 
@@ -310,28 +300,6 @@ export function PreviewPanel({
     }
   }
 
-  // The picker truncates the blocks list behind "Show more" while browsing, but
-  // hidden items can't match the Autocomplete filter — so the full list renders
-  // whenever a search is underway (the filter then prunes it).
-  const onPickerOpenChange = (open: boolean) => {
-    if (!open && keepPickerOpen.current) {
-      keepPickerOpen.current = false
-      return
-    }
-    setPickerOpen(open)
-    if (!open) {
-      // Fresh picker on reopen — collapsed list, cleared search.
-      setShowAllPreviews(false)
-      setPickerQuery("")
-    }
-  }
-
-  const previewsExpanded = showAllPreviews || pickerQuery.trim() !== ""
-  const visiblePreviews = previewsExpanded
-    ? PREVIEW_ITEMS
-    : PREVIEW_ITEMS.slice(0, PREVIEW_ITEMS_COLLAPSED)
-  const hiddenPreviewCount = PREVIEW_ITEMS.length - visiblePreviews.length
-
   // Warm a preview's chunk inside the iframe while the pointer hovers its
   // picker item, so the switch on click is instant.
   const prefetchPreview = (slug: string) =>
@@ -342,18 +310,14 @@ export function PreviewPanel({
   // from the wrapping Select, so the ListBox carries no props of its own.
   const renderPicker = (listClassName: string) => (
     <Command className="min-h-0 flex-1">
-      <SearchField
-        autoFocus
-        aria-label="Search previews"
-        onChange={setPickerQuery}
-      >
+      <SearchField autoFocus aria-label="Search previews">
         <Input placeholder="Search previews…" />
       </SearchField>
       <ListBox className={listClassName}>
         {/* Real-world previews — the whole system composed into full screens. */}
         <ListBoxSection>
           <ListBoxSectionHeader>Blocks</ListBoxSectionHeader>
-          {visiblePreviews.map((block) => (
+          {PREVIEW_ITEMS.map((block) => (
             <ListBoxItem
               key={block.slug}
               id={block.slug}
@@ -363,13 +327,6 @@ export function PreviewPanel({
               <span className="truncate">{block.name}</span>
             </ListBoxItem>
           ))}
-          {hiddenPreviewCount > 0 && (
-            <ListBoxItem id={SHOW_ALL_PREVIEWS_ID} textValue="Show more">
-              <span className="truncate text-fg-muted">
-                Show {hiddenPreviewCount} more…
-              </span>
-            </ListBoxItem>
-          )}
         </ListBoxSection>
         <ListBoxSection>
           <ListBoxSectionHeader>Components</ListBoxSectionHeader>
@@ -487,17 +444,12 @@ export function PreviewPanel({
             <Select
               value={effectivePreview}
               onChange={(v) => {
-                if (v === SHOW_ALL_PREVIEWS_ID) {
-                  setShowAllPreviews(true)
-                  keepPickerOpen.current = true
-                  return
-                }
                 navigate({
                   search: (prev) => ({ ...prev, preview: v as string }),
                 })
               }}
               isOpen={pickerOpen}
-              onOpenChange={onPickerOpenChange}
+              onOpenChange={setPickerOpen}
               aria-label="Preview"
               // w-fit overrides the field base's w-full, which would collapse the
               // trigger inside the pill's shrink-to-fit absolute box.
@@ -517,7 +469,7 @@ export function PreviewPanel({
               {isMobile ? (
                 <Drawer
                   isOpen={pickerOpen}
-                  onOpenChange={onPickerOpenChange}
+                  onOpenChange={setPickerOpen}
                   className="h-[80svh]"
                 >
                   <DialogContent

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -15,12 +15,16 @@ export const Route = createFileRoute("/preview/$slug")({
         : undefined,
   }),
   ssr: false,
-  beforeLoad: ({ params }) => {
-    // Warm the example chunk without pulling the examples barrel into the
-    // router's critical import graph.
-    void import("./-preview-page").then(({ getExamplesPromise }) =>
-      getExamplesPromise(params.slug),
-    )
+  loader: async ({ params }) => {
+    // The example chunk must resolve here, not in the component: while a
+    // loader pends the router keeps the previous preview on screen, whereas a
+    // component that suspends blanks the page (there is no boundary above it —
+    // and no transition can hold it, since router state updates flow through
+    // useSyncExternalStore and render synchronously). The dynamic import keeps
+    // the examples barrel out of the router's critical import graph.
+    const { getExamplesPromise } = await import("./-preview-page")
+    const mod = await getExamplesPromise(params.slug)
+    return { Examples: mod?.default ?? null }
   },
   component: PreviewPage,
 })

--- a/www/src/routes/preview/-preview-page.tsx
+++ b/www/src/routes/preview/-preview-page.tsx
@@ -1,10 +1,4 @@
-import {
-  type ReactNode,
-  startTransition,
-  use,
-  useCallback,
-  useState,
-} from "react"
+import { type ReactNode, useCallback, useState } from "react"
 import { getRouteApi } from "@tanstack/react-router"
 
 import { DesignSystemProvider } from "@/lib/styles"
@@ -72,19 +66,17 @@ export function PreviewPage() {
   // The parent switches previews by navigating this document's own router — the
   // iframe never remounts, so the module cache and design-system state survive
   // and revisited previews render instantly. `replace` keeps these switches out
-  // of the shared browsing history; the transition keeps the current preview on
-  // screen while a first-visit chunk loads instead of unmounting to a blank.
+  // of the shared browsing history; the route loader keeps the current preview
+  // on screen while a first-visit chunk loads.
   usePreviewNavigationMessages({
     onNavigate: useCallback(
       (next: string) => {
         if (next === slug) return
-        startTransition(() => {
-          void navigate({
-            to: "/preview/$slug",
-            params: { slug: next },
-            search: (prev) => prev,
-            replace: true,
-          })
+        void navigate({
+          to: "/preview/$slug",
+          params: { slug: next },
+          search: (prev) => prev,
+          replace: true,
         })
       },
       [slug, navigate],
@@ -94,27 +86,25 @@ export function PreviewPage() {
     }, []),
   })
 
-  // Declared above the `use()` below on purpose: a render that suspends never
-  // commits, so this effect first runs once the example chunk has resolved.
+  // The route loader resolved the example chunk before this render, so this
+  // effect runs with the previewed content committed.
   useAnnouncePreviewReady()
 
   // The "overview" slug isn't a component/group example — it's a bespoke style-guide
   // view that needs the raw designSystem (for the generated color ramps), so it's
   // rendered directly here rather than through the generated examples index.
+  const { Examples } = route.useLoaderData()
   let content: ReactNode
   if (slug === "overview") {
     content = <PresetOverview designSystem={designSystem} />
-  } else {
-    const promise = getExamplesPromise(slug)
-    if (!promise) {
-      return (
-        <div className="flex h-screen items-center justify-center">
-          <span className="text-fg-muted">Preview not found</span>
-        </div>
-      )
-    }
-    const { default: Examples } = use(promise)
+  } else if (Examples) {
     content = <Examples />
+  } else {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <span className="text-fg-muted">Preview not found</span>
+      </div>
+    )
   }
 
   const embedded = typeof window !== "undefined" && window.self !== window.top

--- a/www/src/routes/preview/-preview-page.tsx
+++ b/www/src/routes/preview/-preview-page.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, use, useCallback, useState } from "react"
+import {
+  type ReactNode,
+  startTransition,
+  use,
+  useCallback,
+  useState,
+} from "react"
 import { getRouteApi } from "@tanstack/react-router"
 
 import { DesignSystemProvider } from "@/lib/styles"
@@ -11,6 +17,7 @@ import { DEFAULTS } from "@/modules/create/preset/defaults"
 import {
   useAnnouncePreviewReady,
   useIframeMessageListener,
+  usePreviewNavigationMessages,
 } from "@/modules/create/preset/iframe-sync"
 import type { DesignSystem } from "@/modules/create/preset/types"
 import { BlocksIndex } from "@/modules/create/preview/blocks"
@@ -56,9 +63,36 @@ export function PreviewPage() {
     preset ? decodePreset(preset) : DEFAULTS,
   )
 
+  const navigate = route.useNavigate()
+
   useIframeMessageListener(
     useCallback((ds: DesignSystem) => setDesignSystem(ds), []),
   )
+
+  // The parent switches previews by navigating this document's own router — the
+  // iframe never remounts, so the module cache and design-system state survive
+  // and revisited previews render instantly. `replace` keeps these switches out
+  // of the shared browsing history; the transition keeps the current preview on
+  // screen while a first-visit chunk loads instead of unmounting to a blank.
+  usePreviewNavigationMessages({
+    onNavigate: useCallback(
+      (next: string) => {
+        if (next === slug) return
+        startTransition(() => {
+          void navigate({
+            to: "/preview/$slug",
+            params: { slug: next },
+            search: (prev) => prev,
+            replace: true,
+          })
+        })
+      },
+      [slug, navigate],
+    ),
+    onPrefetch: useCallback((next: string) => {
+      void getExamplesPromise(next)
+    }, []),
+  })
 
   // Declared above the `use()` below on purpose: a render that suspends never
   // commits, so this effect first runs once the example chunk has resolved.


### PR DESCRIPTION
## What

Switching previews in /create showed a loader on every navigation: the preview iframe carried `key={effectivePreview}`, so each switch destroyed the document and re-booted the whole SPA (load, hydrate, fetch the block chunk, wait for `preview-ready`). The module-level chunk cache in the preview page died with the document, so it never helped across switches.

The iframe is now mounted once with a frozen src, and preview switches go over the existing postMessage channel:

- New `preview-navigate` / `preview-prefetch` messages in `iframe-sync.ts`, handled in the preview page by driving the iframe's own TanStack router (`replace: true` so switches never pollute the shared browser history).
- The example chunk is resolved in the route **loader** (replacing the old fire-and-forget `beforeLoad` warm-up), and the component reads it from loader data instead of suspending on `use()`. While a loader pends the router keeps the previous preview on screen, so switches never blank — a suspending component would fall back to an empty page (nothing above it catches suspension, and no transition can hold it since router state updates flow through `useSyncExternalStore`).
- The /create loader overlay now appears only on the initial boot.
- Picker items send `preview-prefetch` on hover, so a block's chunk is warm by click time.
- "Open in new tab" builds its URL at click time (the frozen src no longer reflects the current preview or mode).

Revisited previews render instantly from the document's module cache; first visits keep the current block visible until the next one commits, like a browser navigation.

For reference, shadcn's `(create)` builder remounts per item and mitigates it with Next `<Link prefetch>`; navigating in-iframe avoids the document re-boot entirely.

## Review notes

- The navigate send uses the same resend-on-load/ready dance as the design-system/mode/inspector channels, so a switch made while the initial document is still booting isn't lost; the iframe ignores same-slug sends.
- The navigation hook is registered before `useAnnouncePreviewReady` on purpose — effects run in hook order, so the listener exists before the ready announcement that triggers the parent's resend.
- Verified live: same iframe DOM node across picker switches, parent URL stays in sync, revisits make zero network requests, and a cold first visit produces a single DOM mutation batch (old content held for the full chunk load, no intermediate empty commit). Hover couldn't be simulated in the automated pane (react-aria ignores synthetic pointer events) — worth one manual hover-then-click check.