### PR TITLE
fix(www): drop last table row border doubling the container border

### DIFF
--- a/www/src/modules/create/preview/blocks/customers.tsx
+++ b/www/src/modules/create/preview/blocks/customers.tsx
@@ -1100,7 +1100,7 @@ export default function CustomersBlock() {
                   textValue={customer.name}
                 >
                   {(column) => (
-                    <TableCell className={column.cellClassName}>
+                    <TableCell className={cn("h-12", column.cellClassName)}>
                       {renderCell(customer, column.id)}
                     </TableCell>
                   )}

--- a/www/src/registry/ui/table/styles.ts
+++ b/www/src/registry/ui/table/styles.ts
@@ -8,10 +8,15 @@ const { useStyles, styles } = createStyles(tableMeta, {
       container:
         "relative isolate min-h-0 w-full scroll-pt-10 overflow-auto rounded-md border border-border bg-bg",
       table: "min-w-full text-sm text-fg outline-hidden select-none",
+      // The blur lives on the cells, not the thead: a backdrop-filter is
+      // clipped by its own border-radius but escapes the scroll container's
+      // rounded clip (Chromium), so the corner cells round themselves to the
+      // container's inner radius and the thead must stay filter-free.
       header:
-        "sticky top-0 z-10 bg-bg/95 backdrop-blur supports-[-moz-appearance:none]:bg-bg",
+        "sticky top-0 z-10 bg-bg/95 supports-[-moz-appearance:none]:bg-bg",
       column: [
         "box-border h-10 cursor-default border-b border-border bg-bg/95 px-2.5 text-left align-middle font-medium whitespace-nowrap text-fg-muted focus-reset outline-hidden backdrop-blur supports-[-moz-appearance:none]:bg-bg",
+        "first:rounded-tl-[calc(var(--radius-md)-1px)] last:rounded-tr-[calc(var(--radius-md)-1px)]",
         "[&:is(div)]:flex [&:is(div)]:h-full [&:is(div)]:items-center",
         "relative hover:text-fg focus-visible:z-20 focus-visible:text-fg focus-visible:before:pointer-events-none focus-visible:before:absolute focus-visible:before:inset-0 focus-visible:before:rounded-md focus-visible:before:[outline:2px_solid_var(--color-border-focus)] focus-visible:before:[outline-offset:-2px] focus-visible:before:content-['']",
       ],
@@ -19,6 +24,7 @@ const { useStyles, styles } = createStyles(tableMeta, {
       columnLabel: "min-w-0 flex-1 truncate",
       chromeColumn: [
         "box-border h-10 border-b border-border bg-bg/95 px-0 text-left align-middle focus-reset outline-hidden backdrop-blur supports-[-moz-appearance:none]:bg-bg",
+        "first:rounded-tl-[calc(var(--radius-md)-1px)] last:rounded-tr-[calc(var(--radius-md)-1px)]",
         "[&:is(div)]:flex [&:is(div)]:h-full [&:is(div)]:items-center",
         "relative focus-visible:z-20 focus-visible:before:pointer-events-none focus-visible:before:absolute focus-visible:before:inset-0 focus-visible:before:rounded-md focus-visible:before:[outline:2px_solid_var(--color-border-focus)] focus-visible:before:[outline-offset:-2px] focus-visible:before:content-['']",
       ],

--- a/www/src/registry/ui/table/styles.ts
+++ b/www/src/registry/ui/table/styles.ts
@@ -30,10 +30,9 @@ const { useStyles, styles } = createStyles(tableMeta, {
         "resizing:w-0.5 resizing:bg-border-focus resizing:pl-[7px]",
       ],
       body: "data-[empty]:h-24 data-[empty]:text-center data-[empty]:text-fg-muted",
-      footer:
-        "border-t bg-muted/50 font-medium [&_[role=row]]:last:border-b-0 [&>tr]:last:border-b-0",
+      footer: "border-t bg-muted/50 font-medium",
       row: [
-        "group/row relative box-border cursor-default border-b border-border bg-bg/70 focus-reset transition-colors [&:is(div)]:h-full",
+        "group/row relative box-border cursor-default border-b border-border bg-bg/70 focus-reset transition-colors last:border-b-0 [&:is(div)]:h-full",
         "hover:bg-muted/50 data-[state=selected]:bg-accent-muted pressed:bg-muted/70 selected:bg-accent-muted dragging:cursor-grabbing dragging:bg-accent-muted/70 dragging:text-fg dragging:opacity-70 drop-target:bg-accent-muted/70",
         "focus-visible:bg-accent-muted/70 disabled:text-fg-disabled focus-visible:[&>*:first-child]:shadow-[inset_3px_0_0_0_var(--color-border-focus)]",
       ],


### PR DESCRIPTION
Two rendering bugs made table corners look cropped wherever a table renders (docs demos, preview blocks, /create).

## Bottom corners — doubled border

Every body row carried \`border-b border-border\`, including the last row — whose border sat flush against the \`TableContainer\`'s own bottom border. That inner 1px line is straight and gets clipped square where the container's \`rounded-md\` corner curves away, so both bottom corners read as a doubled, cropped border.

- Added \`last:border-b-0\` to the \`row\` slot — the equivalent of shadcn's \`[&_tr:last-child]:border-0\` on tbody.
- Removed the footer slot's now-redundant \`[&_[role=row]]:last:border-b-0 [&>tr]:last:border-b-0\` — footer rows are \`TableRow\`s, so the row slot covers them; the footer's own \`border-t\` still separates it from the body.

## Top corners — sticky header blur escaping the rounded clip

The sticky header (thead **and** its cells) carried \`backdrop-blur\`. In Chromium a backdrop-filter is clipped by the element's **own** border-radius but escapes the ancestor scroll container's rounded clip — so the square blur patch re-painted the sampled border pixels straight across the corner curve, showing the top border overshooting past the arc.

- Removed \`backdrop-blur\` from the \`header\` slot (thead can't take a radius clip; the cell-level blur it duplicated fully covers it).
- Gave the first/last header cells their own matching top radius (\`calc(var(--radius-md) - 1px)\`, the container's inner radius) on the \`column\` and \`chromeColumn\` slots, so the remaining cell-level blur is clipped at the corners. The translucent blur header look is unchanged.

Checked the rest of the registry for the same pattern: modal and tooltip blurs carry their own radius, so the table was the only case.

## Verification

- Reproduced both artifacts at 10× magnification in the browser; A/B-toggled backdrop-filter to confirm the top-corner mechanism, and confirmed both corners render a single clean arc after the fix (blur still active on cells).
- No regressions for footers (\`border-t\` kept) or infinite-scroll tables (the borderless \`loadMore\` row is tbody's last child there).
- \`pnpm build:registry\`, \`pnpm check\`, \`pnpm typecheck\` pass.