### PR TITLE
fix(www): pin picker search fields and open pickers on their selection

### DIFF
--- a/www/src/components/search-dialog.tsx
+++ b/www/src/components/search-dialog.tsx
@@ -206,7 +206,7 @@ export default function SearchDialog({
               it rather than on the wrapper. */}
         <MenuContent
           aria-label="Search results"
-          className="max-h-80 overflow-y-auto p-1.5 pt-3 **:data-menu-item:py-2 max-md:max-h-none max-md:min-h-0 max-md:grow"
+          className="max-h-80 overflow-y-auto p-1.5 pt-3 max-md:max-h-none max-md:min-h-0 max-md:grow"
           onAction={onClose}
           renderEmptyState={() => (
             <div className="py-8 text-center text-sm text-fg-muted">

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -115,6 +115,30 @@ export function PreviewPanel({
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
+
+  // Open the picker centered on the selected item: the autocomplete's virtual
+  // focus starts at the top, so react-aria never scrolls to the selection.
+  // Retried briefly — the collection DOM mounts a few frames after the open.
+  // Offset math, not scrollIntoView: the popover's entering scale skews rects.
+  useEffect(() => {
+    if (!pickerOpen) return
+    let tries = 0
+    let timer: ReturnType<typeof setTimeout>
+    const attempt = () => {
+      const option = document.querySelector<HTMLElement>(
+        '[data-listbox] [role="option"][aria-selected="true"]',
+      )
+      const scroller = option?.offsetParent
+      if (option && scroller instanceof HTMLElement) {
+        scroller.scrollTop =
+          option.offsetTop - (scroller.clientHeight - option.offsetHeight) / 2
+      } else if (++tries < 20) {
+        timer = setTimeout(attempt, 16)
+      }
+    }
+    attempt()
+    return () => clearTimeout(timer)
+  }, [pickerOpen])
   const [inspecting, setInspecting] = useState(false)
   const [toolbarHidden, setToolbarHidden] = useState(false)
 
@@ -477,12 +501,14 @@ export function PreviewPanel({
                     className="flex h-full min-h-0 flex-col gap-0 p-0"
                   >
                     <DrawerHandle />
-                    {renderPicker("min-h-0 flex-1 overflow-y-auto")}
+                    {/* relative: the options' offsetTop then reads against the
+                        scroller for the scroll-to-selection effect. */}
+                    {renderPicker("relative min-h-0 flex-1 overflow-y-auto")}
                   </DialogContent>
                 </Drawer>
               ) : (
                 <Popover placement="top" className="w-64">
-                  {renderPicker("max-h-72 overflow-y-auto")}
+                  {renderPicker("relative max-h-72 overflow-y-auto")}
                 </Popover>
               )}
             </Select>

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -104,7 +104,11 @@ export function PresetPicker({
   const content = (surface: "popover" | "drawer") => (
     <DialogContent
       aria-label="Presets"
-      className="flex flex-col gap-0 rounded-[inherit] p-0"
+      // `max-h-[inherit]` chains the popover's computed max-height (set inline
+      // by react-aria from the available space) down to the list, so the
+      // search field stays pinned and the list owns all the overflow — the
+      // surface then always fits the space react-aria positioned it for.
+      className="flex max-h-[inherit] flex-col gap-0 rounded-[inherit] p-0"
     >
       {({ close }) => (
         <PresetPickerContent
@@ -280,6 +284,9 @@ function PresetPickerContent({
           gap: 4,
           padding: "0 8px 8px",
           maxHeight: surface === "popover" ? 420 : "60vh",
+          // Shrink below the content when the inherited max-height is tighter
+          // than the 420 cap.
+          minHeight: 0,
           overflowY: "auto",
           scrollPaddingBlock: 8,
         }}
@@ -344,12 +351,14 @@ function PresetPickerContent({
   return (
     <>
       <Command
-        className="gap-0 overflow-hidden p-0"
+        className="max-h-[inherit] gap-0 overflow-hidden p-0"
         onKeyDownCapture={(e) => {
           if (e.key.startsWith("Arrow")) navigatedRef.current = true
         }}
       >
-        <div className="flex w-[260px] shrink-0 flex-col">{list}</div>
+        <div className="flex max-h-[inherit] w-[260px] shrink-0 flex-col">
+          {list}
+        </div>
       </Command>
       {flyout && (
         <PresetPreviewFlyout

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -273,6 +273,8 @@ function PresetPickerContent({
         // and `overflow-visible` on us through descendant selectors that any
         // class of ours would lose to.
         style={{
+          // Relative so the rows' offsetTop reads against the scroller.
+          position: "relative",
           display: "flex",
           flexDirection: "column",
           gap: 4,
@@ -438,8 +440,21 @@ function PresetOptionRow({
     else onHide?.(item.id)
   }, [isHovered, isFocused, item.id, onShow, onHide])
 
+  // Center the selected row when it enters the list: the collection carries no
+  // selection (rows draw their own), so RAC never scrolls to it on open.
+  // Offset math, not scrollIntoView — the popover's entering scale skews rects.
+  const rowRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!isSelected) return
+    const option = rowRef.current?.closest<HTMLElement>("[data-listbox-item]")
+    const scroller = option?.offsetParent
+    if (!option || !(scroller instanceof HTMLElement)) return
+    scroller.scrollTop =
+      option.offsetTop - (scroller.clientHeight - option.offsetHeight) / 2
+  }, [isSelected])
+
   return (
-    <div className="relative w-full">
+    <div ref={rowRef} className="relative w-full">
       <DesignSystemProvider
         scoped
         params={designSystem.componentParams}

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -311,11 +311,9 @@ function PresetPickerContent({
                 textValue={item.name}
                 // The themed row IS the option and covers the item edge to edge,
                 // so the list highlight never shows; hover/focus render on the
-                // row instead (`before:hidden` drops the highlight style's own
-                // accent bar, which would paint the site's accent over the
-                // preset's). `overflow-visible` lets the focus ring and the
+                // row instead. `overflow-visible` lets the focus ring and the
                 // selected badge sit outside the row.
-                className="block overflow-visible rounded-xl p-0 before:hidden"
+                className="block overflow-visible rounded-xl p-0"
               >
                 {({ isHovered, isFocusVisible }) => (
                   <PresetOptionRow

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -314,6 +314,9 @@ function PresetPickerContent({
                 // row instead. `overflow-visible` lets the focus ring and the
                 // selected badge sit outside the row.
                 className="block overflow-visible rounded-xl p-0"
+                // Inline: the Command's drawer/modal row-size rules are
+                // descendant selectors our classes lose to.
+                style={{ padding: 0 }}
               >
                 {({ isHovered, isFocusVisible }) => (
                   <PresetOptionRow

--- a/www/src/registry/ui/card/styles.ts
+++ b/www/src/registry/ui/card/styles.ts
@@ -5,7 +5,7 @@ import cardMeta from "./meta"
 const { useStyles, styles } = createStyles(cardMeta, {
   base: {
     slots: {
-      root: "group/card flex flex-col rounded-(--card-radius) border border-border-muted bg-card shadow-[var(--shadow-card,none)] has-[>img:first-child]:pt-0 *:[img]:first:rounded-t-(--card-radius) *:[img]:last:rounded-b-(--card-radius)",
+      root: "group/card flex flex-col rounded-(--card-radius) border border-border-muted bg-card shadow-[var(--shadow-card,none)] [--surface-radius:var(--card-radius)] has-[>img:first-child]:pt-0 *:[img]:first:rounded-t-(--card-radius) *:[img]:last:rounded-b-(--card-radius)",
       header:
         "group/card-header @container/card-header grid auto-rows-min items-start rounded-t-(--card-radius) has-data-card-action:grid-cols-[1fr_auto] has-data-card-description:grid-rows-[auto_auto]",
       title: "font-heading",

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -11,6 +11,10 @@ const { useStyles, styles } = createStyles(commandMeta, {
       "max-h-[inherit]",
       "**:data-search-field:shrink-0",
       "**:data-listbox:min-h-0 **:data-listbox:overflow-y-auto",
+      // Modal and drawer commands are spotlight/touch surfaces — roomier rows
+      // than a dropdown.
+      "in-data-modal:**:data-listbox-item:px-2 in-data-modal:**:data-listbox-item:py-2 in-data-modal:**:data-menu-item:px-2 in-data-modal:**:data-menu-item:py-2",
+      "in-data-drawer:**:data-listbox-item:px-2 in-data-drawer:**:data-listbox-item:py-2 in-data-drawer:**:data-menu-item:px-2 in-data-drawer:**:data-menu-item:py-2",
     ],
   },
   density: {

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -30,14 +30,15 @@ const { useStyles, styles } = createStyles(commandMeta, {
           "**:data-search-field:px-1.5 **:data-search-field:pt-1.5 **:data-search-field:pb-0",
           "**:data-listbox:scroll-py-1.5 **:data-listbox:px-1.5 **:data-listbox:pt-0 **:data-listbox:pb-1.5",
           "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5",
-          "**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--popover-radius)-(--spacing(1.5)))]",
-          // Cards round with the panel radius, not the popover's.
-          "in-data-card:**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--card-radius)-(--spacing(1.5)))]",
+          // --surface-radius: set by whichever rounded surface contains the
+          // command (popover, modal, card), so one rule stays concentric
+          // everywhere.
+          "**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--surface-radius,var(--radius-surface))-(--spacing(1.5)))]",
           // The modal is a bigger surface — roomier inset to match.
           "in-data-modal:**:data-search-field:px-2 in-data-modal:**:data-search-field:pt-2",
           "in-data-modal:**:data-listbox:scroll-py-2 in-data-modal:**:data-listbox:px-2 in-data-modal:**:data-listbox:pb-2",
           "in-data-modal:**:data-listbox:**:data-separator:-mx-2",
-          "in-data-modal:**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--modal-radius)-(--spacing(2)))]",
+          "in-data-modal:**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--surface-radius,var(--radius-surface))-(--spacing(2)))]",
         ],
       },
       2: {

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -25,7 +25,7 @@ const { useStyles, styles } = createStyles(commandMeta, {
           // The shell inset lives on the search field (margins) and inside the
           // scrolling list (padding) — never on the root, so the list runs to
           // the popover edge and the scrollbar sits flush against it.
-          "**:data-search-field:mx-1.5 **:data-search-field:mt-1.5 **:data-search-field:pb-0",
+          "**:data-search-field:px-1.5 **:data-search-field:pt-1.5 **:data-search-field:pb-0",
           "**:data-listbox:scroll-py-1.5 **:data-listbox:px-1.5 **:data-listbox:pt-0 **:data-listbox:pb-1.5",
           "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
         ],
@@ -44,7 +44,9 @@ const { useStyles, styles } = createStyles(commandMeta, {
           // hairline's geometry) and the list's own padding, so the scrollbar
           // sits flush against the popover edge.
           "gap-2",
-          "**:data-search-field:mx-2 **:data-search-field:mt-2",
+          // w-auto: margins keep the hairline inset, and the field's base
+          // w-full would otherwise add them on top of the full width.
+          "**:data-search-field:w-auto **:data-search-field:mx-2 **:data-search-field:mt-2",
           "**:data-listbox:scroll-py-2 **:data-listbox:px-2 **:data-listbox:pt-0 **:data-listbox:pb-2",
           "**:[[data-search-field]>[data-input-group]]:border-0 **:[[data-search-field]>[data-input-group]]:bg-transparent **:[[data-search-field]>[data-input-group]]:ring-0",
           "**:data-search-field:border-b **:data-search-field:pb-1.5",

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -23,11 +23,19 @@ const { useStyles, styles } = createStyles(commandMeta, {
       1: {
         base: [
           // The shell inset lives on the search field and inside the scrolling
-          // list — never on the root, so the list runs to the popover edge and
-          // the scrollbar sits flush against it.
+          // list — never on the root, so the list runs to the surface edge and
+          // the scrollbar sits flush against it. The input radius stays
+          // concentric by subtracting the inset from the container's own
+          // radius var.
           "**:data-search-field:px-1.5 **:data-search-field:pt-1.5 **:data-search-field:pb-0",
           "**:data-listbox:scroll-py-1.5 **:data-listbox:px-1.5 **:data-listbox:pt-0 **:data-listbox:pb-1.5",
-          "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
+          "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5",
+          "**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--popover-radius)-(--spacing(1.5)))]",
+          // The modal is a bigger surface — roomier inset to match.
+          "in-data-modal:**:data-search-field:px-2.5 in-data-modal:**:data-search-field:pt-2.5",
+          "in-data-modal:**:data-listbox:scroll-py-2.5 in-data-modal:**:data-listbox:px-2.5 in-data-modal:**:data-listbox:pb-2.5",
+          "in-data-modal:**:data-listbox:**:data-separator:-mx-2.5",
+          "in-data-modal:**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--modal-radius)-(--spacing(2.5)))]",
         ],
       },
       2: {

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -31,6 +31,8 @@ const { useStyles, styles } = createStyles(commandMeta, {
           "**:data-listbox:scroll-py-1.5 **:data-listbox:px-1.5 **:data-listbox:pt-0 **:data-listbox:pb-1.5",
           "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5",
           "**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--popover-radius)-(--spacing(1.5)))]",
+          // Cards round with the panel radius, not the popover's.
+          "in-data-card:**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--card-radius)-(--spacing(1.5)))]",
           // The modal is a bigger surface — roomier inset to match.
           "in-data-modal:**:data-search-field:px-2 in-data-modal:**:data-search-field:pt-2",
           "in-data-modal:**:data-listbox:scroll-py-2 in-data-modal:**:data-listbox:px-2 in-data-modal:**:data-listbox:pb-2",

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -32,10 +32,10 @@ const { useStyles, styles } = createStyles(commandMeta, {
           "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5",
           "**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--popover-radius)-(--spacing(1.5)))]",
           // The modal is a bigger surface — roomier inset to match.
-          "in-data-modal:**:data-search-field:px-2.5 in-data-modal:**:data-search-field:pt-2.5",
-          "in-data-modal:**:data-listbox:scroll-py-2.5 in-data-modal:**:data-listbox:px-2.5 in-data-modal:**:data-listbox:pb-2.5",
-          "in-data-modal:**:data-listbox:**:data-separator:-mx-2.5",
-          "in-data-modal:**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--modal-radius)-(--spacing(2.5)))]",
+          "in-data-modal:**:data-search-field:px-2 in-data-modal:**:data-search-field:pt-2",
+          "in-data-modal:**:data-listbox:scroll-py-2 in-data-modal:**:data-listbox:px-2 in-data-modal:**:data-listbox:pb-2",
+          "in-data-modal:**:data-listbox:**:data-separator:-mx-2",
+          "in-data-modal:**:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--modal-radius)-(--spacing(2)))]",
         ],
       },
       2: {

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -22,9 +22,9 @@ const { useStyles, styles } = createStyles(commandMeta, {
     style: {
       1: {
         base: [
-          // The shell inset lives on the search field (margins) and inside the
-          // scrolling list (padding) — never on the root, so the list runs to
-          // the popover edge and the scrollbar sits flush against it.
+          // The shell inset lives on the search field and inside the scrolling
+          // list — never on the root, so the list runs to the popover edge and
+          // the scrollbar sits flush against it.
           "**:data-search-field:px-1.5 **:data-search-field:pt-1.5 **:data-search-field:pb-0",
           "**:data-listbox:scroll-py-1.5 **:data-listbox:px-1.5 **:data-listbox:pt-0 **:data-listbox:pb-1.5",
           "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
@@ -46,7 +46,7 @@ const { useStyles, styles } = createStyles(commandMeta, {
           "gap-2",
           // w-auto: margins keep the hairline inset, and the field's base
           // w-full would otherwise add them on top of the full width.
-          "**:data-search-field:w-auto **:data-search-field:mx-2 **:data-search-field:mt-2",
+          "**:data-search-field:mx-2 **:data-search-field:mt-2 **:data-search-field:w-auto",
           "**:data-listbox:scroll-py-2 **:data-listbox:px-2 **:data-listbox:pt-0 **:data-listbox:pb-2",
           "**:[[data-search-field]>[data-input-group]]:border-0 **:[[data-search-field]>[data-input-group]]:bg-transparent **:[[data-search-field]>[data-input-group]]:ring-0",
           "**:data-search-field:border-b **:data-search-field:pb-1.5",

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -6,10 +6,11 @@ const { useStyles, styles } = createStyles(commandMeta, {
   base: {
     base: [
       "group/command flex w-full flex-col gap-1 text-fg",
-      "max-h-[inherit] overflow-y-auto",
-
-      // ListBox — frameless, scrollable
-      // "**:data-listbox:max-h-72 **:data-listbox:scroll-py-1 **:data-listbox:overflow-y-auto **:data-listbox:p-0 **:data-listbox:outline-hidden",
+      // The search field stays pinned; the list owns all the overflow so the
+      // collection's own scroll (keyboard focus, scroll-into-view) works.
+      "max-h-[inherit]",
+      "**:data-search-field:shrink-0",
+      "**:data-listbox:min-h-0 **:data-listbox:overflow-y-auto",
     ],
   },
   density: {
@@ -21,7 +22,7 @@ const { useStyles, styles } = createStyles(commandMeta, {
     style: {
       1: {
         base: [
-          "p-1.5 **:data-listbox:overflow-visible **:data-listbox:p-0 **:data-search-field:pb-0 **:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
+          "p-1.5 **:data-listbox:p-0 **:data-search-field:pb-0 **:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
         ],
       },
       2: {

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -22,7 +22,12 @@ const { useStyles, styles } = createStyles(commandMeta, {
     style: {
       1: {
         base: [
-          "p-1.5 **:data-listbox:p-0 **:data-search-field:pb-0 **:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
+          // The shell inset lives on the search field (margins) and inside the
+          // scrolling list (padding) — never on the root, so the list runs to
+          // the popover edge and the scrollbar sits flush against it.
+          "**:data-search-field:mx-1.5 **:data-search-field:mt-1.5 **:data-search-field:pb-0",
+          "**:data-listbox:scroll-py-1.5 **:data-listbox:px-1.5 **:data-listbox:pt-0 **:data-listbox:pb-1.5",
+          "**:data-listbox:**:data-separator:-mx-1.5 **:data-listbox:**:data-separator:my-1.5 **:[[data-search-field]>[data-input-group]]:rounded-[calc(var(--radius-panel)-(--spacing(1.5)))]",
         ],
       },
       2: {
@@ -34,8 +39,13 @@ const { useStyles, styles } = createStyles(commandMeta, {
       },
       3: {
         base: [
-          // Vercel ⌘K: padded shell, frameless input on an inset hairline, flush list.
-          "gap-2 p-2 **:data-listbox:p-0",
+          // Vercel ⌘K: padded shell, frameless input on an inset hairline,
+          // flush list. The inset rides the search field (margins keep the
+          // hairline's geometry) and the list's own padding, so the scrollbar
+          // sits flush against the popover edge.
+          "gap-2",
+          "**:data-search-field:mx-2 **:data-search-field:mt-2",
+          "**:data-listbox:scroll-py-2 **:data-listbox:px-2 **:data-listbox:pt-0 **:data-listbox:pb-2",
           "**:[[data-search-field]>[data-input-group]]:border-0 **:[[data-search-field]>[data-input-group]]:bg-transparent **:[[data-search-field]>[data-input-group]]:ring-0",
           "**:data-search-field:border-b **:data-search-field:pb-1.5",
           "**:data-listbox:**:data-separator:mx-0 **:data-listbox:**:data-separator:my-1.5",

--- a/www/src/registry/ui/drawer/base.tsx
+++ b/www/src/registry/ui/drawer/base.tsx
@@ -140,6 +140,7 @@ function Drawer({
                 <DrawerPrimitive.Backdrop className={backdrop()} />
                 <DrawerPrimitive.Viewport className={viewport({ placement })}>
                   <DrawerPrimitive.Popup
+                    data-drawer=""
                     data-base-ui-swipe-ignore={swipeToDismiss ? undefined : ""}
                     initialFocus={() => getInitialFocusTarget(popupRef.current)}
                     className={(state) =>

--- a/www/src/registry/ui/list-box/styles.ts
+++ b/www/src/registry/ui/list-box/styles.ts
@@ -66,9 +66,6 @@ const { useStyles, styles } = createStyles(listBoxMeta, {
   params: {
     highlight: {
       subtle: {
-        slots: {
-          item: "overflow-hidden focus-visible:before:absolute focus-visible:before:inset-y-0 focus-visible:before:left-0 focus-visible:before:w-0.5 focus-visible:before:rounded-[inherit] focus-visible:before:bg-accent",
-        },
         vars: {
           "--color-highlight": "var(--neutral-200)",
           "--color-fg-on-highlight": "var(--neutral-950)",

--- a/www/src/registry/ui/menu/styles.ts
+++ b/www/src/registry/ui/menu/styles.ts
@@ -53,9 +53,6 @@ const { useStyles, styles } = createStyles(menuMeta, {
   params: {
     highlight: {
       subtle: {
-        slots: {
-          item: "overflow-hidden focus-visible:before:absolute focus-visible:before:inset-y-0 focus-visible:before:left-0 focus-visible:before:w-0.5 focus-visible:before:rounded-[inherit] focus-visible:before:bg-accent",
-        },
         vars: {
           "--color-highlight": "var(--neutral-200)",
           "--color-fg-on-highlight": "var(--neutral-950)",

--- a/www/src/registry/ui/menu/styles.ts
+++ b/www/src/registry/ui/menu/styles.ts
@@ -32,15 +32,15 @@ const { useStyles, styles } = createStyles(menuMeta, {
     compact: {
       slots: {
         root: "text-xs/relaxed",
-        item: "min-h-7 gap-2 px-1.5 py-1 text-xs/relaxed **:[svg]:not-with-[size]:size-3.5",
-        sectionTitle: "px-1.5 py-1",
+        item: "min-h-7 gap-2 px-2 py-1 text-xs/relaxed **:[svg]:not-with-[size]:size-3.5",
+        sectionTitle: "px-2 py-1",
       },
     },
     default: {
       slots: {
         root: "text-sm",
-        item: "gap-2 px-2 py-1 text-sm **:[svg]:not-with-[size]:size-4",
-        sectionTitle: "px-2 py-1",
+        item: "gap-1.5 px-1.5 py-1 text-sm **:[svg]:not-with-[size]:size-4",
+        sectionTitle: "px-1.5 py-1",
       },
     },
     comfortable: {

--- a/www/src/registry/ui/modal/styles.ts
+++ b/www/src/registry/ui/modal/styles.ts
@@ -15,7 +15,7 @@ const { useStyles, styles } = createStyles(modalMeta, {
       viewport:
         "@container-[size] sticky top-0 left-0 flex h-(--visual-viewport-height) w-full items-center justify-center",
       modal: [
-        "relative flex max-h-[calc(var(--visual-viewport-height)-2rem)] w-full max-w-[calc(100vw-2rem)] flex-col rounded-(--modal-radius) border border-border-elevated bg-(--modal-background) shadow-[var(--shadow-overlay,var(--shadow-lg))] sm:max-h-[calc(var(--visual-viewport-height)*.9)]",
+        "relative flex max-h-[calc(var(--visual-viewport-height)-2rem)] w-full max-w-[calc(100vw-2rem)] flex-col rounded-(--modal-radius) border border-border-elevated bg-(--modal-background) shadow-[var(--shadow-overlay,var(--shadow-lg))] [--surface-radius:var(--modal-radius)] sm:max-h-[calc(var(--visual-viewport-height)*.9)]",
         "transition-[opacity,scale] ease-[cubic-bezier(0.165,0.84,0.44,1)]",
         "duration-200 entering:scale-95 entering:opacity-0",
         "exiting:scale-95 exiting:opacity-0 exiting:duration-150",

--- a/www/src/registry/ui/popover/styles.ts
+++ b/www/src/registry/ui/popover/styles.ts
@@ -6,7 +6,7 @@ const { useStyles, styles } = createStyles(popoverMeta, {
   base: {
     slots: {
       popover: [
-        "popover z-50 min-w-[max(var(--trigger-width),--spacing(32))] origin-(--trigger-anchor-point) rounded-(--popover-radius) border border-border-elevated bg-popover shadow-[var(--shadow-overlay,var(--shadow-md))] forced-color-adjust-none outline-none",
+        "popover z-50 min-w-[max(var(--trigger-width),--spacing(32))] origin-(--trigger-anchor-point) rounded-(--popover-radius) border border-border-elevated bg-popover shadow-[var(--shadow-overlay,var(--shadow-md))] forced-color-adjust-none outline-none [--surface-radius:var(--popover-radius)]",
         "transition-[transform,opacity,scale] duration-200 ease-out will-change-[transform,opacity,scale] [--slide-offset:--spacing(0.5)]",
         "entering:scale-95 entering:transform-(--origin) entering:opacity-0",
         "exiting:scale-95 exiting:transform-(--origin) exiting:opacity-0 exiting:duration-150",


### PR DESCRIPTION
## Problem

The pickers built on Command/popover (the preview switcher on /create, and the preset picker) misbehaved around scrolling:

1. **Preview picker (/create toolbar)**: scrolling the list scrolled the search field away with it, and keyboard navigation scrolled the wrong container.
2. **Both pickers**: opening with the selected item in the list's overflow left it out of view.
3. **Preset picker**: the surface also overflowed the popover's react-aria-computed max-height.

## Root causes

- **Registry (`command/styles.ts`)** — the real registry bug: style param 1 forced `**:data-listbox:overflow-visible`, defeating any `overflow-y-auto` the caller puts on the list; with the list unable to scroll, the Command root (`overflow-y-auto` in its base) scrolled everything, search field included. React Aria's keyboard scroll-into-view targets the listbox (its `scrollRef`), so that broke too.
- **App-side** — neither picker scrolls to its selection on open by itself: the preset picker wires no selection into its collection, and the preview picker's list sits under the Command's Autocomplete, whose virtual focus starts at the top even though selection is known.

## Fix

- **Registry `command`**: the root no longer scrolls; the search field is pinned (`shrink-0`) and the listbox owns all overflow (`min-h-0` + `overflow-y-auto` in the base; the `overflow-visible` override removed from style 1). Collection scrolling (keyboard focus, scroll-into-view) now targets the right element.
- **Preview picker** (`preview-panel.tsx`): on open, centers the `aria-selected` option in the scroller (briefly retried — the collection DOM mounts a few frames after open).
- **Preset picker** (`preset-picker.tsx`): `max-h-[inherit]` chains the popover's computed max-height down to the list (search pinned, list takes the remainder), and the selected row centers itself on mount.
- Both scroll effects use offset math rather than `scrollIntoView`: the popover's entering scale animation skews rect-based scrolling, and `scrollIntoView` would also scroll ancestor scrollports.

## Scrollbar placement

A follow-up on the registry fix: the padded command shells (styles 1 and 3) kept their inset by padding the root, which left the scrollbar floating inside the popover padding. The inset now rides the search field (margins — style 3's hairline keeps its geometry) and the list's own padding, so the list runs to the popover edge and the scrollbar sits flush against it. Same rendered look; only the scrollbar moves.

## Verified live

- /create preview picker: search stays pinned while the list scrolls; reopening with "Combobox" selected centers it exactly; `Cards` (top item) opens unscrolled.
- Preset picker (docs toolbar): popover height matches its computed max-height in normal and short (520px) viewports; selection centered on open, clamped at list ends.
- Registry `__generated__` output unchanged by the styles edit (no drift).

## Concentric input radius via `--surface-radius`

The style-1 input radius was concentric only in modals (it subtracted a fixed inset from `--radius-panel`). Each rounded surface (popover, modal, card) now publishes its own radius as an inherited `--surface-radius` var, and the command derives one rule: `calc(var(--surface-radius, var(--radius-surface)) − inset)` — concentric in every container, and future surfaces join by setting the var. The modal keeps a roomier 8px inset (its own `in-data-modal:` spacing block). Verified: popover 10→4px, card 15→9px, modal 15→7px.

## Item spacing and focus treatment

Three follow-ups from comparing against shadcn's style files (mira/nova/vega ≈ compact/default/comfortable):

- **Menu spacing aligned with the shadcn density ladder** — our ListBox already matched shadcn cell-for-cell; Menu had compact/default `px` effectively swapped. Menu now equals ListBox at every density (compact `px-2`, default `px-1.5 gap-1.5`).
- **Keyboard-focus accent bar removed** — the `highlight: subtle` param's `focus-visible` accent edge bar is gone from both menu and list-box items; keyboard focus keeps the neutral highlight wash. The preset picker's `before:hidden` defense against that bar is deleted with it.
- **Roomier command rows in modals and drawers** — `in-data-modal:`/`in-data-drawer:` bump listbox and menu items to `px-2 py-2` (8px, the docs-search look; dropdowns stay `4px 6px`). The drawer popup now carries `data-drawer`, the docs search's per-callsite `py-2` hack is removed (the registry rule covers it, including its mobile drawer), and the preset picker pins `padding: 0` inline since its themed cards are the rows.