### PR TITLE
refactor(www): open interactive demo controls in a popover

### DIFF
--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -9,12 +9,14 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   SlidersHorizontalIcon,
-  XIcon,
 } from "lucide-react"
 import type { PressEvent } from "react-aria-components"
+import * as DialogPrimitives from "react-aria-components/Dialog"
 
 import { cn } from "@/registry/lib/utils"
 import { Button } from "@/registry/ui/button"
+import { DialogContent } from "@/registry/ui/dialog"
+import { Popover } from "@/registry/ui/popover"
 import { Tooltip, TooltipContent } from "@/registry/ui/tooltip"
 import { CodeBlock } from "@/modules/docs/code-block"
 import { renderCode } from "@/modules/docs/codegen/code-template"
@@ -32,11 +34,8 @@ import type { ControlValues, SerializableControl } from "./types"
  * Interactive demo component.
  * Renders the playground, controls, and live code output.
  *
- * The preview is the hero: the demo owns the full card and the controls hide
- * behind a corner toggle. Opening slides a panel in from the right that *pushes*
- * the preview (the flex sibling reflows) rather than overlaying it — animated
- * with the drawer easing (--ease-fluid-out). The panel takes its natural height,
- * so a tall control set extends the card instead of scrolling.
+ * The preview is the hero: the demo owns the full card and the controls open
+ * from a corner toggle into a popover anchored to it.
  *
  * The displayed code is filled from a build-time template-with-holes over the
  * real demo source (see codegen/source-overlay.ts). Preview and code derive
@@ -59,7 +58,6 @@ export function InteractiveDemo({
   className,
 }: InteractiveDemoProps) {
   const [isExpanded, setIsExpanded] = useState(false)
-  const [controlsOpen, setControlsOpen] = useState(false)
 
   const initialValues = useMemo(
     () => defaultControlValues(controls),
@@ -108,99 +106,48 @@ export function InteractiveDemo({
 
   return (
     <div className={cn("overflow-hidden rounded-lg border", className)}>
-      <div className="flex flex-col md:flex-row">
-        {/* PreviewPanel pins the whole preview column (toolbar + trigger
-            included) to the preview mode; the preset only themes the canvas.
-            While the panel is closed, right padding keeps the mode toggle
-            clear of the trigger pinned in the corner. */}
-        <PreviewPanel className="flex min-w-0 flex-1 flex-col">
-          {/* The panel trigger stays mounted so its visibility can tween;
-              `inert` takes it out of the tab order and the a11y tree while
-              hidden. */}
-          <span className="contents" inert={controlsOpen}>
-            <Tooltip>
-              <Button
-                variant="quiet"
-                size="sm"
-                isIconOnly
-                aria-label="Controls"
-                className={cn(
-                  "absolute top-2 right-2 z-10 text-fg-muted transition-[opacity,scale] duration-300 ease-fluid-out motion-reduce:transition-none",
-                  controlsOpen && "scale-50 opacity-0",
-                )}
-                onPress={() => setControlsOpen(true)}
-              >
-                <SlidersHorizontalIcon />
-              </Button>
-              <TooltipContent>Controls</TooltipContent>
-            </Tooltip>
-          </span>
-          <PreviewControls
-            className={cn(
-              "transition-[padding] duration-300 ease-fluid-out motion-reduce:transition-none",
-              !controlsOpen && "pr-11",
-            )}
-          />
-          <DemoPreset>
-            <div className="flex min-h-56 flex-1 items-center justify-center bg-bg p-10 pt-14">
-              {previewElement}
-            </div>
-          </DemoPreset>
-        </PreviewPanel>
-
-        {/* Controls column — slides in from the right and pushes the preview (the
-            preview is flex-1, so it gives up width as the column grows). The column
-            stretches to the row height and carries the bg/divider, so its surface
-            always fills the panel — no gap while the height animates. */}
-        <div
-          className={cn(
-            "overflow-hidden border-t bg-card transition-[width,opacity,display] transition-discrete duration-300 ease-fluid-out motion-reduce:transition-none md:shrink-0 md:border-t-0 md:border-l",
-            "starting:opacity-0 md:starting:w-0",
-            controlsOpen
-              ? "block w-full opacity-100 md:w-56"
-              : "hidden w-full opacity-0 md:w-0",
-          )}
-        >
-          {/* Inner wrapper animates its height from the closed row height (h-56,
-              = the preview's min height) up to content via interpolate-size. Starting
-              at h-56 (not 0) means the card height isn't clamped by the preview, so it
-              grows in lock-step with the width — same start, duration, and easing. */}
-          <div
-            className={cn(
-              "**:data-field:gap-1 **:data-label:text-[0.8125rem] **:data-label:text-fg-muted",
-              "w-full overflow-hidden transition-[height] duration-300 ease-fluid-out [interpolate-size:allow-keywords] motion-reduce:transition-none md:w-56 starting:h-56",
-              controlsOpen ? "h-auto" : "h-56",
-            )}
+      {/* PreviewPanel pins the whole preview column (toolbar + trigger
+          included) to the preview mode; the preset only themes the canvas.
+          Right padding keeps the mode toggle clear of the trigger pinned in
+          the corner. */}
+      <PreviewPanel className="flex min-w-0 flex-col">
+        <DialogPrimitives.DialogTrigger>
+          <Tooltip>
+            <Button
+              variant="quiet"
+              size="sm"
+              isIconOnly
+              aria-label="Controls"
+              className="absolute top-2 right-2 z-10 text-fg-muted"
+            >
+              <SlidersHorizontalIcon />
+            </Button>
+            <TooltipContent>Controls</TooltipContent>
+          </Tooltip>
+          <Popover
+            placement="right top"
+            className="w-56 p-4 **:data-field:gap-1 **:data-label:text-[0.8125rem] **:data-label:text-fg-muted"
           >
-            <div className="flex flex-col gap-4 px-5 pt-3 pb-5">
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-fg-muted">
-                  Controls
-                </span>
-                <Tooltip>
-                  <Button
-                    variant="quiet"
-                    size="sm"
-                    isIconOnly
-                    aria-label="Hide controls"
-                    className="-mr-2 text-fg-muted hover:text-fg"
-                    onPress={() => setControlsOpen(false)}
-                  >
-                    <XIcon className="size-3.5" />
-                  </Button>
-                  <TooltipContent>Hide controls</TooltipContent>
-                </Tooltip>
-              </div>
+            <DialogContent
+              aria-label="Controls"
+              className="flex flex-col gap-4 outline-none"
+            >
               <Controls
                 controls={controls}
                 values={values}
                 onChange={handleChange}
                 layout="horizontal"
               />
-            </div>
+            </DialogContent>
+          </Popover>
+        </DialogPrimitives.DialogTrigger>
+        <PreviewControls className="pr-11" />
+        <DemoPreset>
+          <div className="flex min-h-56 flex-1 items-center justify-center bg-bg p-10 pt-14">
+            {previewElement}
           </div>
-        </div>
-      </div>
+        </DemoPreset>
+      </PreviewPanel>
 
       {/* Code bar — split from the panel above by a single thin divider */}
       <CodeBlock


### PR DESCRIPTION
The interactive demo's controls now open in a popover anchored to the corner trigger (placement `right top`) instead of the push-in side panel.

- Replaces the animated width/height push-panel with `DialogTrigger` + `Popover` from the registry.
- Drops the `controlsOpen` state, the close (X) header row, and the panel transition plumbing — the popover dismisses on outside click/Esc.
- Trigger stays pinned in the preview corner; `PreviewControls` keeps permanent right padding to clear it.

Verified in the dev server on /docs/components/button: popover opens right of the card, top-aligned, controls drive the preview and code as before.