### PR TITLE
fix(www): resolve param CSS vars from registry metas

### DIFF
--- a/www/src/lib/styles.tsx
+++ b/www/src/lib/styles.tsx
@@ -42,6 +42,7 @@ import type {
   ParamDef,
   RegistryItem,
 } from "@/registry/types"
+import { registryUi } from "@/registry/ui/registry"
 
 /* --------------------------------- Types --------------------------------- */
 
@@ -63,21 +64,36 @@ const DesignSystemContext = React.createContext<DesignSystemContextValue>({
   density: "default",
 })
 
-/* ----------------------------- Param registry ----------------------------- */
+/* ----------------------------- Param bindings ----------------------------- */
+
+const emptyParamSelections: Record<string, string> = {}
 
 /**
- * Module-scoped registry populated by `createStyles` at module load. The
- * provider reads it to resolve the user's per-component selections into CSS
- * vars on `:root`. Two kinds:
- *   - enum vars: `{ [component]: { [paramName]: { [valueName]: vars } } }`
- *   - scalar bindings: `{ [component]: { [paramName]: cssVar } }`
+ * Param → CSS var bindings derived from the registry metas: enum values' `vars`
+ * blocks (`{ [component]: { [paramName]: { [valueName]: vars } } }`) and scalar
+ * params' `cssVar` (`{ [component]: { [paramName]: cssVar } }`). Deliberately
+ * NOT registered by `createStyles` at module load: that would make the
+ * provider's inline vars depend on which styles modules happen to be evaluated,
+ * which differs between the server (accretes every SSR'd route in the dev
+ * process) and the client (only the current page's chunks) — a hydration
+ * mismatch. Metas are plain data both environments always share.
  */
-const enumVarsRegistry = new Map<
+const enumVarBindings = new Map<
   string,
   Record<string, Record<string, Record<string, string>>>
 >()
-const scalarVarsRegistry = new Map<string, Record<string, string>>()
-const emptyParamSelections: Record<string, string> = {}
+const scalarVarBindings = new Map<string, Record<string, string>>()
+for (const item of registryUi) {
+  if (!item.params) continue
+  const enumVars: Record<string, Record<string, Record<string, string>>> = {}
+  const scalars: Record<string, string> = {}
+  for (const [paramName, def] of Object.entries(item.params)) {
+    if (def.kind === "scalar") scalars[paramName] = def.cssVar
+    else if (def.vars) enumVars[paramName] = def.vars
+  }
+  if (Object.keys(enumVars).length > 0) enumVarBindings.set(item.name, enumVars)
+  if (Object.keys(scalars).length > 0) scalarVarBindings.set(item.name, scalars)
+}
 
 /* -------------------------------- Provider ------------------------------- */
 
@@ -390,8 +406,8 @@ function DesignSystemProvider({
     // Enum params write a value's `vars` block; scalar params write a single
     // CSS var resolved from the selected token reference.
     for (const [componentName, componentSelections] of Object.entries(params)) {
-      const enumVars = enumVarsRegistry.get(componentName)
-      const scalarBindings = scalarVarsRegistry.get(componentName)
+      const enumVars = enumVarBindings.get(componentName)
+      const scalarBindings = scalarVarBindings.get(componentName)
       for (const [paramName, paramValue] of Object.entries(
         componentSelections,
       )) {
@@ -703,9 +719,7 @@ type EnumParamsConfig<M, Base> = [EnumParamNamesOf<M>] extends [never]
   : {
       params?: {
         [K in EnumParamNamesOf<M>]?: {
-          [V in EnumParamValuesOf<M, K> & string]?: ExtendingTv<Base> & {
-            vars?: Record<string, string>
-          }
+          [V in EnumParamValuesOf<M, K> & string]?: ExtendingTv<Base>
         }
       }
     }
@@ -746,53 +760,15 @@ function createStyles<const M extends RegistryItem, const Base>(
   const { base, density, params } = config as {
     base: Base
     density?: Record<Density, Record<string, unknown>>
-    params?: Record<
-      string,
-      Record<
-        string,
-        Record<string, unknown> & { vars?: Record<string, string> }
-      >
-    >
+    params?: Record<string, Record<string, Record<string, unknown>>>
   }
 
-  /* ----- Register param vars / scalar bindings into runtime registry ----- */
   const metaParams = (meta.params ?? {}) as Record<string, ParamDef>
   const enumParamNames: string[] = []
   const paramDefaults: Record<string, string> = {}
-
-  const enumVarsForComponent: Record<
-    string,
-    Record<string, Record<string, string>>
-  > = {}
-  const scalarBindingsForComponent: Record<string, string> = {}
-
   for (const [paramName, def] of Object.entries(metaParams)) {
     paramDefaults[paramName] = def.default
-    if (def.kind === "enum") {
-      enumParamNames.push(paramName)
-      const valueVarsByValue: Record<string, Record<string, string>> = {}
-      const valuesConfig = (params?.[paramName] ?? {}) as Record<
-        string,
-        { vars?: Record<string, string> }
-      >
-      let hasAny = false
-      for (const [valueName, valueConfig] of Object.entries(valuesConfig)) {
-        if (valueConfig?.vars && Object.keys(valueConfig.vars).length > 0) {
-          valueVarsByValue[valueName] = valueConfig.vars
-          hasAny = true
-        }
-      }
-      if (hasAny) enumVarsForComponent[paramName] = valueVarsByValue
-    } else if (def.kind === "scalar") {
-      scalarBindingsForComponent[paramName] = def.cssVar
-    }
-  }
-
-  if (Object.keys(enumVarsForComponent).length > 0) {
-    enumVarsRegistry.set(meta.name, enumVarsForComponent)
-  }
-  if (Object.keys(scalarBindingsForComponent).length > 0) {
-    scalarVarsRegistry.set(meta.name, scalarBindingsForComponent)
+    if (def.kind === "enum") enumParamNames.push(paramName)
   }
 
   /* ----- Build per-density tv functions ----- */
@@ -812,12 +788,6 @@ function createStyles<const M extends RegistryItem, const Base>(
   }
 
   /* ----- Composition: base → density → params(in declared order) ----- */
-  function stripVars<T extends { vars?: unknown }>(input: T): Omit<T, "vars"> {
-    // tv() can't see the `vars` key, so drop it before passing through.
-    const { vars: _vars, ...rest } = input
-    return rest as Omit<T, "vars">
-  }
-
   function compose(
     d: Density,
     paramSelection: Record<string, string>,
@@ -829,12 +799,10 @@ function createStyles<const M extends RegistryItem, const Base>(
         paramSelection[paramName] ?? paramDefaults[paramName]
       if (!selectedValue) continue
       const valueConfig = params?.[paramName]?.[selectedValue]
-      if (!valueConfig) continue
-      const tvOverride = stripVars(valueConfig)
-      if (Object.keys(tvOverride).length === 0) continue
+      if (!valueConfig || Object.keys(valueConfig).length === 0) continue
       current = tv({
         extend: current as never,
-        ...(tvOverride as Parameters<typeof tv>[0]),
+        ...(valueConfig as Parameters<typeof tv>[0]),
       } as never)
     }
     return current

--- a/www/src/lib/styles.wrong-types.test.ts
+++ b/www/src/lib/styles.wrong-types.test.ts
@@ -29,6 +29,7 @@ const fixtureMeta = {
       kind: "enum",
       default: "default",
       values: ["default", "alt"] as const,
+      vars: { alt: { "--fixture-bg": "var(--neutral-100)" } },
     },
     highlight: {
       kind: "enum",
@@ -84,7 +85,6 @@ createStyles(fixtureMeta, {
       default: { slots: { root: "border" } },
       alt: {
         slots: { item: "italic" },
-        vars: { "--fixture-bg": "var(--neutral-100)" },
       },
     },
     highlight: {
@@ -225,14 +225,14 @@ createStyles(fixtureMeta, {
   },
 })
 
-/* 11) Params: vars must be Record<string, string>, not number values */
+/* 11) Params: `vars` lives in meta now, not the styles config */
 createStyles(fixtureMeta, {
   base: baseConfig.base,
   params: {
     style: {
       alt: {
-        // @ts-expect-error — vars values must be strings
-        vars: { "--x": 12 },
+        // @ts-expect-error — vars is not a styles-config key
+        vars: { "--x": "var(--neutral-100)" },
       },
     },
   },

--- a/www/src/registry/types.ts
+++ b/www/src/registry/types.ts
@@ -48,14 +48,20 @@ export type RegistryItemFile = NonNullable<ShadcnRegistryItem["files"]>[number]
 
 /**
  * An "enum" param: user picks one of a fixed set of named values.
- * Each value can carry tv slices and/or CSS vars in `createStyles`.
- * Covers what was previously `meta.styles` (aesthetic) and `meta.params`
+ * Each value can carry tv slices in `createStyles` and/or CSS vars in `vars`
+ * here. Covers what was previously `meta.styles` (aesthetic) and `meta.params`
  * (per-component variants).
  */
 export type EnumParamDef = {
   kind: "enum"
   default: string
   values: readonly string[]
+  /**
+   * CSS vars a value sets on the provider scope, keyed by value name. Lives in
+   * meta (not the styles config) so the provider can resolve selections from
+   * data both server and client always share — like `ScalarParamDef.cssVar`.
+   */
+  vars?: Record<string, Record<`--${string}`, string>>
   files?: Record<string, readonly RegistryItemFile[]>
   description?: string
 }

--- a/www/src/registry/ui/list-box/meta.ts
+++ b/www/src/registry/ui/list-box/meta.ts
@@ -18,6 +18,16 @@ const listBoxMeta = {
       kind: "enum",
       default: "subtle",
       values: ["subtle", "accent"] as const,
+      vars: {
+        subtle: {
+          "--color-highlight": "var(--neutral-200)",
+          "--color-fg-on-highlight": "var(--neutral-950)",
+        },
+        accent: {
+          "--color-highlight": "var(--accent-700)",
+          "--color-fg-on-highlight": "var(--on-accent-700)",
+        },
+      },
       description: "How focused/active items are highlighted.",
     },
   },

--- a/www/src/registry/ui/list-box/styles.ts
+++ b/www/src/registry/ui/list-box/styles.ts
@@ -65,19 +65,9 @@ const { useStyles, styles } = createStyles(listBoxMeta, {
   },
   params: {
     highlight: {
-      subtle: {
-        vars: {
-          "--color-highlight": "var(--neutral-200)",
-          "--color-fg-on-highlight": "var(--neutral-950)",
-        },
-      },
       accent: {
         slots: {
           item: "hover:not-in-data-[trigger=ComboBox]:not-in-data-[trigger=Select]:**:text-current focus:in-[:is([data-trigger=ComboBox],[data-trigger=Select])]:**:text-current",
-        },
-        vars: {
-          "--color-highlight": "var(--accent-700)",
-          "--color-fg-on-highlight": "var(--on-accent-700)",
         },
       },
     },

--- a/www/src/registry/ui/menu/meta.ts
+++ b/www/src/registry/ui/menu/meta.ts
@@ -24,6 +24,16 @@ const menuMeta = {
       kind: "enum",
       default: "subtle",
       values: ["subtle", "accent"] as const,
+      vars: {
+        subtle: {
+          "--color-highlight": "var(--neutral-200)",
+          "--color-fg-on-highlight": "var(--neutral-950)",
+        },
+        accent: {
+          "--color-highlight": "var(--accent-700)",
+          "--color-fg-on-highlight": "var(--on-accent-700)",
+        },
+      },
       description: "How focused/active items are highlighted.",
     },
   },

--- a/www/src/registry/ui/menu/styles.ts
+++ b/www/src/registry/ui/menu/styles.ts
@@ -50,22 +50,6 @@ const { useStyles, styles } = createStyles(menuMeta, {
       },
     },
   },
-  params: {
-    highlight: {
-      subtle: {
-        vars: {
-          "--color-highlight": "var(--neutral-200)",
-          "--color-fg-on-highlight": "var(--neutral-950)",
-        },
-      },
-      accent: {
-        vars: {
-          "--color-highlight": "var(--accent-700)",
-          "--color-fg-on-highlight": "var(--on-accent-700)",
-        },
-      },
-    },
-  },
 })
 
 export type MenuStyles = typeof styles

--- a/www/src/registry/ui/tooltip/meta.ts
+++ b/www/src/registry/ui/tooltip/meta.ts
@@ -16,6 +16,12 @@ const tooltipMeta = {
       kind: "enum",
       default: "default",
       values: ["default", "translucid"] as const,
+      vars: {
+        translucid: {
+          "--color-tooltip": "var(--neutral-200)",
+          "--color-fg-on-tooltip": "var(--neutral-950)",
+        },
+      },
       description: "How the tooltip surface is rendered.",
     },
     radius: {

--- a/www/src/registry/ui/tooltip/styles.ts
+++ b/www/src/registry/ui/tooltip/styles.ts
@@ -30,10 +30,6 @@ const { useStyles, styles } = createStyles(tooltipMeta, {
         slots: {
           content: ["relative bg-tooltip/70 backdrop-blur-[2px]"],
         },
-        vars: {
-          "--color-tooltip": "var(--neutral-200)",
-          "--color-fg-on-tooltip": "var(--neutral-950)",
-        },
       },
     },
   },


### PR DESCRIPTION
## What

The landing page's scoped `DesignSystemProvider` logged a hydration mismatch: the server-rendered inline style carried `--tooltip-radius` and `--color-swatch-picker-item-radius` while the client render omitted them.

## Why

The provider resolved param selections into inline CSS vars through module-scoped registries (`enumVarsRegistry` / `scalarVarsRegistry`) populated by `createStyles` at module load. Which registrations exist therefore depends on which `styles.ts` modules happen to be evaluated — and that differs between environments: the dev SSR process accretes every route rendered in its lifetime, while the client only evaluates the current page's chunks. Once any request SSR'd a route importing tooltip or color-swatch-picker (neither is used by a showcase card), every later home-page SSR inlined their vars and hydration mismatched. Reproduced empirically: a fresh dev server's first home SSR omits both vars; after one request to the tooltip docs page they appear permanently.

## How

Derive all param→var bindings from `registryUi` metas — plain data both environments always share:

- `EnumParamDef` gains `vars?: Record<value, Record<--var, string>>`, mirroring how scalar params already carry `cssVar` in meta (meta = the var contract, `styles.ts` = the classes).
- The 5 enum `vars` blocks (tooltip `color.translucid`, menu + list-box `highlight.subtle/accent`) move from `styles.ts` configs into their `meta.ts`.
- `lib/styles.tsx` builds `enumVarBindings` + `scalarVarBindings` once from `registryUi`; the `createStyles`-time registration, `stripVars`, and the `vars?` key in the styles-config typing are deleted.
- Type-fixture test updated: `vars` in a styles config is now asserted to fail compilation.

## Verified

- Fresh dev server: home SSR inline style is byte-stable across requests, including after SSR-ing the tooltip docs page; hydration console clean on home and menu docs pages; vars resolve to real values inside the scope.
- `pnpm check`, `pnpm typecheck`, all 258 tests pass; `build:registry` and `build:references` regenerate with no tracked drift (publishables are gitignored and pick up the new shape).

## Suggested refactors

Noticed in passing, left alone (publisher rewrite is queued): the publisher strips enum `vars` at `flatten()` and `emit-theme` never writes them, so an exported preset selecting e.g. `menu.highlight: accent` ships the tv slices but silently loses the `--color-highlight` remap. Also: several meta param defaults disagree with the CSS-declared defaults (e.g. badge `--radius-md` vs CSS `var(--radius-full)`), making the "default" inline vars load-bearing.