### PR TITLE
fix(www): render chart card shells on first paint

### DIFF
--- a/www/src/modules/charts/chart-card.tsx
+++ b/www/src/modules/charts/chart-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Suspense, useState } from "react"
+import { Suspense, useEffect, useRef, useState } from "react"
 import { RotateCcwIcon } from "lucide-react"
 
 import { cn } from "@/registry/lib/utils"
@@ -9,6 +9,40 @@ import { ShowcaseCard } from "@/components/showcase-card"
 
 import { ChartCodeModal } from "./chart-code-modal"
 import { getDemoComponent, POLAR_FAMILIES } from "./data"
+
+/**
+ * Mounts the chart once the card comes near the viewport; until then the card
+ * surface stays empty. The page stacks ~60 live Recharts previews; mounting
+ * them all at once blocks the main thread for seconds, so offscreen charts wait
+ * their turn. Only the chart body is deferred — the card shell renders on
+ * first paint.
+ */
+function LazyChartBody({ children }: { children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setVisible(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: "600px 0px" },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref} className="size-full">
+      {visible && children}
+    </div>
+  )
+}
 
 interface ChartCardProps {
   /** Family id, e.g. `chart-bar` — decides polar vs cartesian sizing. */
@@ -61,20 +95,20 @@ export function ChartCard({ familyId, demoKey, label }: ChartCardProps) {
       inert
       aria-hidden="true"
     >
-      {/* Skeleton fills the whole box edge-to-edge; padding lives on the chart
-          wrapper so it never insets the fallback. */}
-      <Suspense fallback={<div className="size-full animate-pulse bg-muted" />}>
-        <div
-          className={cn(
-            "flex size-full items-center justify-center p-9 [&_*]:pointer-events-none [&_[data-slot=chart]]:h-full! [&_[data-slot=chart]]:min-h-0!",
-            isPolar
-              ? "[&_[data-slot=chart]]:mx-auto! [&_[data-slot=chart]]:aspect-square! [&_[data-slot=chart]]:max-h-[250px]! [&_[data-slot=chart]]:w-auto!"
-              : "[&_[data-slot=chart]]:aspect-auto! [&_[data-slot=chart]]:w-full!",
-          )}
-        >
-          <Component key={replayKey} />
-        </div>
-      </Suspense>
+      <LazyChartBody>
+        <Suspense fallback={null}>
+          <div
+            className={cn(
+              "flex size-full animate-in items-center justify-center p-9 duration-300 fade-in [&_*]:pointer-events-none [&_[data-slot=chart]]:h-full! [&_[data-slot=chart]]:min-h-0!",
+              isPolar
+                ? "[&_[data-slot=chart]]:mx-auto! [&_[data-slot=chart]]:aspect-square! [&_[data-slot=chart]]:max-h-[250px]! [&_[data-slot=chart]]:w-auto!"
+                : "[&_[data-slot=chart]]:aspect-auto! [&_[data-slot=chart]]:w-full!",
+            )}
+          >
+            <Component key={replayKey} />
+          </div>
+        </Suspense>
+      </LazyChartBody>
     </ShowcaseCard>
   )
 }

--- a/www/src/modules/charts/chart-family-grid.tsx
+++ b/www/src/modules/charts/chart-family-grid.tsx
@@ -1,42 +1,7 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
-
 import { ChartCard } from "./chart-card"
 import { CHART_FAMILIES, variantsFor } from "./data"
-
-/**
- * Mounts its children once they come near the viewport. The page stacks ~60
- * live Recharts previews; mounting them all at once blocks the main thread for
- * seconds, so offscreen cards wait their turn. The placeholder matches
- * ChartCard's rendered height (header row + h-80 card) so nothing shifts.
- */
-function LazyMount({ children }: { children: React.ReactNode }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const [visible, setVisible] = useState(false)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          setVisible(true)
-          observer.disconnect()
-        }
-      },
-      { rootMargin: "600px 0px" },
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [])
-
-  return (
-    <div ref={ref} className="h-[22.25rem]">
-      {visible && children}
-    </div>
-  )
-}
 
 /**
  * Renders the chart previews for a single family, identified by its registry id
@@ -58,9 +23,12 @@ export function ChartFamilyGrid({ family }: { family: string }) {
   return (
     <div className="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
       {variantsFor(data.id).map((v) => (
-        <LazyMount key={v.key}>
-          <ChartCard familyId={data.id} demoKey={v.key} label={v.label} />
-        </LazyMount>
+        <ChartCard
+          key={v.key}
+          familyId={data.id}
+          demoKey={v.key}
+          label={v.label}
+        />
       ))}
     </div>
   )


### PR DESCRIPTION
On /docs/charts every card — chrome included — was wrapped in \`LazyMount\`, which renders nothing until hydration + IntersectionObserver, so first paint showed blank gaps and whole cards popped in (layout flicker).

Mirrors shadcn's charts page approach: the card shells (header row + framed surface) are server-rendered and present on first paint; only the chart body is viewport-deferred. Until a chart mounts, the card shows its plain fixed surface (no skeleton), and the chart fades in over 300ms on mount.

- Move the IntersectionObserver from \`ChartFamilyGrid\` into the card as \`LazyChartBody\`, deferring only the chart (same 600px margin — ~60 Recharts previews still never mount at once).
- Drop the pulse skeleton; pre-mount and Suspense states are the bare card surface.
- Add \`animate-in fade-in duration-300\` to the chart wrapper.

Verified via SSR curl: 57 card shells in the initial HTML (previously 0); no hydration errors.