### PR TITLE
feat(www): move Open studio button into the global header

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -4,7 +4,7 @@ import { SearchIcon } from "lucide-react"
 
 import { navItems, siteConfig } from "@/config/site"
 import { cn } from "@/registry/lib/utils"
-import { Button, buttonStyles } from "@/registry/ui/button"
+import { Button, buttonStyles, LinkButton } from "@/registry/ui/button"
 import { Separator } from "@/registry/ui/separator"
 import { GitHubIcon } from "@/components/icons/github"
 import { HeaderActionsSlot } from "@/components/layout/header-slot"
@@ -102,6 +102,17 @@ export function Header({ className, items = [] }: HeaderProps) {
         </a>
         <ThemeToggle variant="quiet" isIconOnly />
         <HeaderActionsSlot />
+        {/* On /studio the slot above carries studio-specific actions instead. */}
+        {pathname !== "/studio" && (
+          <LinkButton
+            href="/studio"
+            variant="primary"
+            size="sm"
+            className="ml-1.5"
+          >
+            Open studio
+          </LinkButton>
+        )}
         <Separator orientation="vertical" className="mx-1.5 h-4 lg:hidden" />
         <MobileNav items={items} />
       </div>

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -1,7 +1,6 @@
 import { LinkButton } from "@/registry/ui/button"
 import { Eyebrow } from "@/components/eyebrow"
 import { Footer } from "@/components/layout/footer"
-import { HeaderActions } from "@/components/layout/header-slot"
 import Cards from "@/modules/marketing/cards"
 import { CtaSection } from "@/modules/marketing/cta-section"
 import { HeroWordSwap } from "@/modules/marketing/hero-word-swap"
@@ -24,16 +23,6 @@ export function HomePage() {
     // content box. Decorations that bleed past it (cards rails, full-bleed
     // washes) are clipped at the viewport by the root.
     <div className="overflow-x-clip">
-      <HeaderActions>
-        <LinkButton
-          href="/studio"
-          variant="primary"
-          size="sm"
-          className="ml-1.5"
-        >
-          Open studio
-        </LinkButton>
-      </HeaderActions>
       <div className="container">
         {/* Hero section */}
         <section className="flex flex-col pt-10 sm:pt-14 md:pt-20">


### PR DESCRIPTION
The **Open studio** button was only on the landing page because it was injected per-page through the `HeaderActions` portal. It's the site's primary CTA, so it now renders in the global header on every page.

- `header.tsx` renders the primary **Open studio** button site-wide, hidden only on `/studio` itself (where the same slot carries the Export action instead).
- Removed the portal injection from `home-page.tsx`; the hero's "Start building" CTA stays.