### PR TITLE
fix(www): widen docs copy-page button icon gap

### DIFF
--- a/www/src/modules/docs/docs-copy-page.tsx
+++ b/www/src/modules/docs/docs-copy-page.tsx
@@ -97,11 +97,7 @@ export function DocsCopyPage({
         className="gap-1.5"
         onPress={() => copyToClipboard(content)}
       >
-        {isCopied ? (
-          <CheckIcon data-icon-start="" />
-        ) : (
-          <CopyIcon data-icon-start="" />
-        )}
+        {isCopied ? <CheckIcon /> : <CopyIcon />}
         Copy page
       </Button>
       <Menu>

--- a/www/src/modules/docs/docs-copy-page.tsx
+++ b/www/src/modules/docs/docs-copy-page.tsx
@@ -92,12 +92,16 @@ export function DocsCopyPage({
 
   return (
     <Group className="hidden sm:flex">
-      <Button size="sm" onPress={() => copyToClipboard(content)}>
+      <Button
+        size="sm"
+        className="gap-1.5"
+        onPress={() => copyToClipboard(content)}
+      >
         {isCopied ? (
           <CheckIcon data-icon-start="" />
         ) : (
           <CopyIcon data-icon-start="" />
-        )}{" "}
+        )}
         Copy page
       </Button>
       <Menu>


### PR DESCRIPTION
## What

- Overrides the docs "Copy page" button gap to \`gap-1.5\` (6px) so it matches shadcn's live docs copy button.
- Removes a stray \`{" "}\` between the icon and label — visually inert (flex leading-space collapse) but it polluted \`textContent\` (" Copy page").

## Why

The button rendered a 4px icon→text gap (\`gap-1\` at \`size="sm"\`). That is exact parity with the new shadcn 3-style bases (mira/nova/vega all use \`gap-1\` at sm), but reads tighter than ui.shadcn.com's own copy-page button, which still runs the pre-3-styles button (\`gap-1.5\`, 16px icon). The override is site-side only — the registry button styles are untouched since they correctly match the 3-style reference.

Verified live: gap renders at 6px, base \`gap-1\` is merged out, \`textContent\` is a clean "Copy page".

## Notes for reviewers

- Icon stays at 14px (\`size-3.5\`); only the gap was widened per request.
- Found in passing, not included here: default-density \`md\` forces \`**:[svg]:size-3.5\` while nova's default size inherits \`size-4\` — our md button icons are 2px smaller than the shadcn reference (\`www/src/registry/ui/button/styles.ts:61\`).