### PR TITLE
docs(www): rewrite hero description and record the vision in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This is the dotUI repository — a design-system builder. Users compose a comple
 
 This is the goal, not the current state — check the code before assuming an axis exists.
 
+The vision: dotUI is the tool for creating a real, professional design system with your own taste — everything a startup needs as a foundation: technically strong, coherent, well built, and made to work well with AI. Create it once, then build on it everywhere — a web component library that matches your brand today; emails, native apps, and other platforms planned. Export widens the same way: the shadcn CLI and v0 today; vibe-coding tools like Bolt and Lovable, plus Figma and more, planned.
+
 The north star: the builder should be flexible enough to recreate almost any design system. If a user can't reproduce the look of a Material-, Geist-, or Linear-style system, an axis is missing. Coverage comes from a complete set of well-chosen axes, not infinite options: **every visual decision is a user-configurable axis of the builder**, never a hardcoded choice. Axes include (not exhaustive):
 
 - Color system: simple or advanced, selectable generation algorithm, semantic tokens, optionally context-aware tokens.
@@ -15,8 +17,6 @@ The north star: the builder should be flexible enough to recreate almost any des
 - For consistency, related components form synced groups: Button and ToggleButton share the same styles and must stay in sync.
 
 A second customization layer beyond visuals: `codeOptions` — the style of the exported code itself. Separator comments or not, arrow functions vs function declarations, tailwind-variants styles as commented arrays vs one line per slot/variant, etc. The exported design system should read like the user's codebase, not ours.
-
-Beyond that, export keeps widening: CLI + v0 today; Bolt, Lovable, Figma, Claude design, etc. planned.
 
 What this means when writing code today:
 

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -47,8 +47,9 @@ export function HomePage() {
               </span>
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-              Every design decision is yours, previewed live on real components.
-              Install with the shadcn CLI, or export straight to v0.
+              Every design decision is yours — create, tweak, and ship code you
+              own.
+              {/* Once a non-web export ships: One foundation for all platforms. */}
             </p>
             <div className="mt-9 flex items-center gap-3">
               <LinkButton href="/studio" variant="primary" size="lg">


### PR DESCRIPTION
## What changed

- Hero description is now a single sentence: **"Every design decision is yours — create, tweak, and ship code you own."** It replaces the previous two-liner ("…previewed live on real components. Install with the shadcn CLI, or export straight to v0.").
- The vision-scale second sentence ("One foundation for all platforms.") is kept as a JSX comment next to the copy, to bring back once a non-web export ships — as a hero claim today it would overpromise (dotUI ships web components only).
- CLAUDE.md: added the product vision to Product direction (professional design system with your own taste, create once / build everywhere, startup foundation, AI-ready, widening exports) and folded the old export-widening line into it.

## Why

The old description listed mechanics; the new one leads with the actual promise — ownership of every decision and of the exported code. The humans/agents beat stays with the rotating headline, so the description no longer repeats it.