### PR TITLE
fix(www): align docs content with header logo below xl

### DIFF
--- a/www/src/routes/_app/docs/-docs-page.tsx
+++ b/www/src/routes/_app/docs/-docs-page.tsx
@@ -104,10 +104,14 @@ export const clientLoader = browserCollections.docs.createClientLoader({
           {hasToc && (
             <div
               className={cn(
-                // From lg the column mirrors the sidebar's width so the
-                // content sits viewport-centered between equal rails.
-                "sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start px-6 pt-10 md:flex lg:w-(--sidebar-width)",
-                !full && "xl:hidden",
+                "sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start px-6 pt-10 md:flex",
+                // Narrow pages mirror the sidebar's width so the body sits
+                // viewport-centered between equal rails — and the xl swap to
+                // the TOC rail doesn't shift it. Wide pages keep a slim rail:
+                // the bars carry no text, so a full-width rail reads as
+                // left-heavy; the slight rightward bias evens out the visible
+                // whitespace on both sides of the body.
+                full ? "lg:w-24" : "lg:w-(--sidebar-width) xl:hidden",
               )}
             >
               <MiniTOC />

--- a/www/src/routes/_app/docs/-docs-page.tsx
+++ b/www/src/routes/_app/docs/-docs-page.tsx
@@ -104,7 +104,9 @@ export const clientLoader = browserCollections.docs.createClientLoader({
           {hasToc && (
             <div
               className={cn(
-                "sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start px-6 pt-10 md:flex",
+                // From lg the column mirrors the sidebar's width so the
+                // content sits viewport-centered between equal rails.
+                "sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start px-6 pt-10 md:flex lg:w-(--sidebar-width)",
                 !full && "xl:hidden",
               )}
             >

--- a/www/src/routes/_app/docs/-docs-page.tsx
+++ b/www/src/routes/_app/docs/-docs-page.tsx
@@ -45,16 +45,18 @@ export const clientLoader = browserCollections.docs.createClientLoader({
               // Padding tracks the header's logo inset (pl-4/md:pl-6). Narrow
               // pages center at every width (left-hugging strands them far from
               // the MiniTOC); wide (full) pages nearly fill the row below lg,
-              // so they hug the left edge to stay aligned with the logo, and
-              // keep lg padding until xl centering slack separates them from
-              // the sidebar and MiniTOC rails.
+              // so they hug the left edge to stay aligned with the logo. From
+              // lg they keep px-8 as a minimum gap against the sidebar and
+              // MiniTOC rails; the cap grows by that padding (60rem = 4xl +
+              // 4rem) so the content holds its full width whenever there's
+              // room, with no snap at any breakpoint.
               "flex w-full min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-6 dark:text-neutral-300",
               // mr-auto: when the column hits max-w below lg, the auto margin
               // absorbs the leftover flex space so the MiniTOC column stays
               // pinned to the viewport edge (aligned with the header's menu
               // button) instead of trailing the capped column.
               full
-                ? "mr-auto max-w-4xl lg:mx-auto lg:px-8 xl:px-0"
+                ? "mr-auto max-w-4xl lg:mx-auto lg:max-w-[60rem] lg:px-8"
                 : "mx-auto max-w-2xl lg:px-0",
             )}
           >

--- a/www/src/routes/_app/docs/-docs-page.tsx
+++ b/www/src/routes/_app/docs/-docs-page.tsx
@@ -42,8 +42,16 @@ export const clientLoader = browserCollections.docs.createClientLoader({
         <PageLayout className="mt-4 flex scroll-mt-24 items-stretch pb-8 text-[1.05rem] sm:text-[15px] xl:w-full">
           <div
             className={cn(
-              "mx-auto flex w-full min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 lg:px-0 dark:text-neutral-300",
-              full ? "max-w-4xl" : "max-w-2xl",
+              // Padding tracks the header's logo inset (pl-4/md:pl-6). Narrow
+              // pages center at every width (left-hugging strands them far from
+              // the MiniTOC); wide (full) pages nearly fill the row below lg,
+              // so they hug the left edge to stay aligned with the logo, and
+              // keep lg padding until xl centering slack separates them from
+              // the sidebar and MiniTOC rails.
+              "flex w-full min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-6 dark:text-neutral-300",
+              full
+                ? "max-w-4xl lg:mx-auto lg:px-8 xl:px-0"
+                : "mx-auto max-w-2xl lg:px-0",
             )}
           >
             <div data-page-header="" className="relative mb-2 space-y-3 pb-4">

--- a/www/src/routes/_app/docs/-docs-page.tsx
+++ b/www/src/routes/_app/docs/-docs-page.tsx
@@ -49,8 +49,12 @@ export const clientLoader = browserCollections.docs.createClientLoader({
               // keep lg padding until xl centering slack separates them from
               // the sidebar and MiniTOC rails.
               "flex w-full min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-6 dark:text-neutral-300",
+              // mr-auto: when the column hits max-w below lg, the auto margin
+              // absorbs the leftover flex space so the MiniTOC column stays
+              // pinned to the viewport edge (aligned with the header's menu
+              // button) instead of trailing the capped column.
               full
-                ? "max-w-4xl lg:mx-auto lg:px-8 xl:px-0"
+                ? "mr-auto max-w-4xl lg:mx-auto lg:px-8 xl:px-0"
                 : "mx-auto max-w-2xl lg:px-0",
             )}
           >

--- a/www/src/routes/_app/docs/route.tsx
+++ b/www/src/routes/_app/docs/route.tsx
@@ -14,7 +14,7 @@ function DocsLayout() {
   const items = pageTree.children as PageTree.Node[]
 
   return (
-    <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:228px]">
+    <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:200px]">
       <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-(--sidebar-width) shrink-0 lg:block">
         <DocsSidebar items={items} />
       </aside>

--- a/www/src/routes/_app/docs/route.tsx
+++ b/www/src/routes/_app/docs/route.tsx
@@ -15,7 +15,7 @@ function DocsLayout() {
 
   return (
     <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:228px]">
-      <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-fit shrink-0 lg:block xl:w-(--sidebar-width)">
+      <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-(--sidebar-width) shrink-0 lg:block">
         <DocsSidebar items={items} />
       </aside>
       <div className="min-w-0 flex-1">


### PR DESCRIPTION
## What

Fixes docs content alignment between 768px and xl, where the misalignment was most visible on the wide (\`full: true\`) components and charts pages:

- The content column padded \`px-4\` (16px) while the header logo sits at \`md:pl-6\` (24px), leaving content 8px left of the logo from md up. Padding now tracks the header inset (\`px-4 md:px-6\`).
- Wide pages self-centered (\`mx-auto\`) once the viewport passed ~960px, drifting further right of the logo. They now hug the left edge below lg and keep \`lg:px-8\` until xl, so the body clears the sidebar and MiniTOC rails (was ~12px against the sidebar at lg, now 44px) instead of touching them.
- Narrow (\`max-w-2xl\`) pages keep centering at every width — left-hugging them stranded the column far from the MiniTOC with a large dead zone on the right.

## Why

Between 768px and lg there is no sidebar, so the content's left edge should line up with the navbar logo; from lg the sidebar and TOC rails need breathing room that the full-width pages didn't leave.

## Verification

Measured live in the browser: logo and h1 both at 24px on /docs/components and /docs/charts at 768/900/975/1010; 44px sidebar→body gap at 1024–1050 and 58px at 1280 on full pages; narrow pages centered (unchanged at lg+). \`pnpm check\` and \`pnpm typecheck\` pass.