### PR TITLE
fix(docs): restore the code-block expand view transition

### DIFF
--- a/www/src/modules/docs/toggle-code-block.ts
+++ b/www/src/modules/docs/toggle-code-block.ts
@@ -1,35 +1,26 @@
-// Animates a code block's expand/collapse as a height tween. Deliberately not
-// a view transition: snapshotting pauses input document-wide (long for a big
-// highlighted file) and participating elements skip hit-testing, so even a
-// transition scoped to the block reads as a frozen page.
+import { flushSync } from "react-dom"
+
+// Expand/collapse morph scoped to one code block. :root is opted out of view
+// transitions globally (see styles.css) so the rest of the page keeps its
+// hit-testing; only the block itself morphs. It's named just for the
+// transition's duration — a static name would duplicate across a page's demos
+// and abort the transition.
 export function toggleCodeBlock(target: Element, update: () => void) {
   const block = target.closest("figure")
-  if (!block || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+  if (
+    !block ||
+    !document.startViewTransition ||
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  ) {
     update()
     return
   }
-  const from = block.getBoundingClientRect().height
-  update()
-  // The re-render can land after the current task (DynamicPre defers
-  // re-highlighting), so tween on the resulting height change instead of
-  // measuring synchronously.
-  const ro = new ResizeObserver(() => {
-    const to = block.getBoundingClientRect().height
-    if (to === from) return
-    ro.disconnect()
-    clearTimeout(bail)
-    for (const animation of block.getAnimations()) animation.cancel()
-    block.style.overflow = "hidden"
-    block
-      .animate([{ height: `${from}px` }, { height: `${to}px` }], {
-        duration: 250,
-        easing: "cubic-bezier(0.215, 0.61, 0.355, 1)",
-      })
-      .finished.finally(() => {
-        block.style.overflow = ""
-      })
-  })
-  ro.observe(block)
-  // A no-op toggle (same height) would leave the observer running forever.
-  const bail = setTimeout(() => ro.disconnect(), 500)
+  block.style.viewTransitionName = "docs-code-block"
+  document
+    .startViewTransition(() => {
+      flushSync(update)
+    })
+    .finished.finally(() => {
+      block.style.viewTransitionName = ""
+    })
 }


### PR DESCRIPTION
## Summary

- #438 set out to keep the page interactive during view transitions, but its second commit replaced the docs code-block expand/collapse morph with a height-only tween. The crossfade was gone: the new code appears at full opacity on the first frame and only the container height animates, which reads as an instant swap. This regression was noticed in the docs demos.
- Restore the scoped view transition from that PR's first commit: `toggleCodeBlock` names the `figure` for the transition's duration and runs `flushSync(update)` inside `startViewTransition`. The global fixes from #438 stay in place (`:root { view-transition-name: none }` and `::view-transition { pointer-events: none }` in `styles.css`), so only the block morphs and the rest of the page keeps its hit-testing.
- Reduced motion skips the transition (the global CSS also kills the pseudo animations).

## Verification

Headless Chrome on `/docs/components/button` (InteractiveDemo, `DynamicPre` deferred highlighting) and `/docs/components/text-field` (`Demo`), expand and collapse, sampling every frame:

- The view-transition pseudo animations run for ~250ms and the block's transition name clears when they finish.
- `document.elementFromPoint` over a sidebar link returns the link on every frame of the transition, except the single snapshot frame.
- `pnpm check` and `pnpm typecheck` pass. No registry files touched.