### PR TITLE
feat(www): move docs search field to the drawer bottom on mobile

### DIFF
--- a/www/src/components/search-command.tsx
+++ b/www/src/components/search-command.tsx
@@ -119,11 +119,9 @@ export function SearchCommand({
           </DialogContent>
         )
         return isMobile ? (
-          // Match the desktop modal's raised surface. Near-full-height sheet
-          // (mirrors base-ui.com's mobile search): the input sits at the top,
-          // structurally clear of the iOS keyboard, and the results list
-          // flexes below it. The drawer's keyboard inset keeps the list's
-          // bottom above the keyboard.
+          // Match the desktop modal's raised surface. Near-full-height sheet:
+          // the results list flexes above the input, which sits at the
+          // bottom — the drawer's keyboard inset keeps it above the keyboard.
           <Drawer className="h-[calc(100dvh_-_3rem_+_var(--drawer-bleed))] bg-(--neutral-100)">
             <DrawerHandle />
             {content}

--- a/www/src/components/search-command.tsx
+++ b/www/src/components/search-command.tsx
@@ -123,7 +123,9 @@ export function SearchCommand({
           // the results list flexes above the input, which sits at the
           // bottom — the drawer's keyboard inset keeps it above the keyboard.
           <Drawer className="h-[calc(100dvh_-_3rem_+_var(--drawer-bleed))] bg-(--neutral-100)">
-            <DrawerHandle />
+            {/* Base UI docs' handle: 56×5 pill floated 5px from the top,
+                content starting 16px down (the list's own top inset). */}
+            <DrawerHandle className="absolute inset-x-0 top-[5px] my-0 h-[5px]! w-14!" />
             {content}
           </Drawer>
         ) : (

--- a/www/src/components/search-dialog.tsx
+++ b/www/src/components/search-dialog.tsx
@@ -185,14 +185,20 @@ export default function SearchDialog({
         data-command=""
         className={commandStyles({
           // On mobile the dialog fills a near-full-height drawer, so the
-          // command column flexes instead of sizing to its content.
-          className: "gap-0 overflow-y-hidden p-0 max-lg:min-h-0 max-lg:grow",
+          // command column flexes instead of sizing to its content, and the
+          // field's shell inset moves to its bottom edge (same specificity as
+          // the command's own **: rules, which outrank plain classes).
+          className:
+            "gap-0 overflow-y-hidden p-0 max-lg:min-h-0 max-lg:grow max-lg:**:data-search-field:pt-0 max-lg:**:data-search-field:pb-1.5",
         })}
       >
+        {/* On mobile the field sits at the bottom of the drawer, thumb-reach
+            and directly above the keyboard (the drawer's keyboard inset pads
+            the popup bottom). */}
         <SearchField
           autoFocus={autoFocus}
           aria-label="Search"
-          className="px-1.5 pt-1.5"
+          className="px-1.5 pt-1.5 max-lg:order-last"
         >
           {/* Radius stays concentric with the modal (2xl − 6px inset); the
               filled input needs no focus treatment, so the ring is off and the
@@ -212,7 +218,7 @@ export default function SearchDialog({
               it rather than on the wrapper. */}
         <MenuContent
           aria-label="Search results"
-          className="max-h-80 overflow-y-auto p-1.5 pt-3 max-lg:max-h-none max-lg:min-h-0 max-lg:grow"
+          className="max-h-80 overflow-y-auto p-1.5 pt-3 max-lg:max-h-none max-lg:min-h-0 max-lg:grow max-lg:pt-1.5 max-lg:pb-3"
           onAction={onClose}
           renderEmptyState={() => (
             <div className="py-8 text-center text-sm text-fg-muted">

--- a/www/src/components/search-dialog.tsx
+++ b/www/src/components/search-dialog.tsx
@@ -218,7 +218,7 @@ export default function SearchDialog({
               it rather than on the wrapper. */}
         <MenuContent
           aria-label="Search results"
-          className="max-h-80 overflow-y-auto p-1.5 pt-3 max-lg:max-h-none max-lg:min-h-0 max-lg:grow max-lg:pt-1.5 max-lg:pb-3"
+          className="max-h-80 overflow-y-auto p-1.5 pt-3 max-lg:max-h-none max-lg:min-h-0 max-lg:grow max-lg:pt-4 max-lg:pb-3"
           onAction={onClose}
           renderEmptyState={() => (
             <div className="py-8 text-center text-sm text-fg-muted">


### PR DESCRIPTION
## Summary

- On mobile, the docs search drawer places the search field at the bottom of the sheet, with the results list flexing above it. Desktop modal unchanged.
- Bottom placement keeps the field within thumb reach and directly above the software keyboard; the drawer's keyboard inset already pads the popup bottom, so the field rises with the keyboard.
- The field's shell inset comes from the command's `**:data-search-field:` rules, which outrank plain classes on the field. The mobile padding flip (top 0, bottom 6px) therefore lives on the command wrapper at the same specificity.
- Verified at 375×812: field autofocuses, typing filters and appends search results above it, bottom inset matches the side inset.
- Results still stack from the top of the list, so with few matches there is a gap above the field. Anchoring results to the bottom is a one-line `justify-end` if preferred.