### PR TITLE
fix(drawer): cancel react-aria presses when a swipe starts

### DIFF
--- a/www/src/registry/ui/drawer/base.tsx
+++ b/www/src/registry/ui/drawer/base.tsx
@@ -40,15 +40,26 @@ function resolveClassName<TState>(
   return typeof className === "function" ? className(state) : className
 }
 
-function stripPopupDialogProps(props: DrawerPopupRenderProps) {
-  const {
-    "aria-describedby": _ariaDescribedBy,
-    "aria-labelledby": _ariaLabelledBy,
-    role: _role,
-    ...presentationProps
-  } = props
+// The popup is a presentation container: the dialog semantics belong to the
+// <Dialog> rendered inside it.
+function DrawerPopupElement({
+  "aria-describedby": _ariaDescribedBy,
+  "aria-labelledby": _ariaLabelledBy,
+  role: _role,
+  swiping,
+  ...props
+}: DrawerPopupRenderProps & { swiping: boolean }) {
+  // A swipe that starts on a pressable (menu item, button) never cancels the
+  // react-aria press: the content moves with the finger, so the pointer stays
+  // over the target, and the drawer claims the gesture before the browser
+  // would fire pointercancel. Releasing then fires onPress. Cancel in-flight
+  // presses the way the platform does when a gesture is taken over.
+  React.useEffect(() => {
+    if (!swiping) return
+    document.dispatchEvent(new PointerEvent("pointercancel"))
+  }, [swiping])
 
-  return presentationProps
+  return <div {...props} />
 }
 
 function getInitialFocusTarget(popupElement: HTMLDivElement | null) {
@@ -149,12 +160,9 @@ function Drawer({
                         className: resolveClassName(className, state),
                       })
                     }
-                    render={(renderProps) => {
-                      const presentationProps =
-                        stripPopupDialogProps(renderProps)
-
-                      return <div {...presentationProps} />
-                    }}
+                    render={(renderProps, { swiping }) => (
+                      <DrawerPopupElement {...renderProps} swiping={swiping} />
+                    )}
                     ref={popupRef}
                     style={style}
                   >


### PR DESCRIPTION
## Summary

- Dragging the docs search drawer from a result navigated to that result on release. Every Drawer was affected, not just search.
- Root cause: react-aria's `usePress` only cancels on `pointercancel` / `pointerleave` / `dragstart`. During a swipe none fire — the content moves with the finger so the pointer never leaves the item, and base-ui calls `preventDefault` on `touchmove` so the browser never takes over the gesture. On release the press is still live; `usePress` waits 80ms for a native click and, finding none, calls `target.click()` itself (its iOS long-press workaround). That synthesized click navigates.
- Fix: the popup element now renders through a small `DrawerPopupElement` that reads base-ui's `swiping` state and dispatches a `pointercancel` on the document when a swipe starts — the same signal the platform sends when a gesture is claimed. In-flight presses cancel and the item un-highlights as the drag begins.

## Verification

Headless Chrome + Puppeteer touch events, 375px viewport, docs search drawer:

| Scenario | Before | After |
|---|---|---|
| Drag 180px from the "Docs" item | swipe engaged, item clicked, navigated | swipe engaged, no click, no navigation |
| Plain tap on an item | — | navigates and closes |
| Long swipe | — | dismisses without navigating |

`pnpm check`, `tsc --noEmit` pass; `pnpm build:registry` produced no tracked changes.