### PR TITLE
fix(docs): default install tabs to pnpm and remember the last choice

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "typescript": "catalog:",
     "vitest": "^4.0.16"
   },
-  "packageManager": "pnpm@11.5.3"
+  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85"
 }

--- a/www/source.config.ts
+++ b/www/source.config.ts
@@ -49,5 +49,11 @@ export default defineConfig({
       tab: true,
     },
     rehypePlugins: [rehypeTransform],
+    // ```npm blocks become package-manager tabs. `persist` adds `groupId` so
+    // <CodeBlockTabs> binds them to the shared packageManagerStore (pnpm by
+    // default, the user's last pick remembered).
+    remarkNpmOptions: {
+      persist: { id: "package-manager" },
+    },
   },
 })

--- a/www/src/modules/docs/code-block-tabs.tsx
+++ b/www/src/modules/docs/code-block-tabs.tsx
@@ -9,14 +9,24 @@ import type {
 import { packageManagerStore } from "./install-commands"
 import type { PackageManager } from "./install-commands"
 
+/**
+ * Code tabs. With a `groupId` (fumadocs' remarkNpm emits
+ * `groupId="package-manager"` for ```npm blocks when `persist` is on, and the
+ * install modals pass it by hand) the tabs are bound to `packageManagerStore`,
+ * so every install snippet shows pnpm by default and follows the user's last
+ * pick. Without one they are plain uncontrolled tabs.
+ */
 export function CodeBlockTabs({
   groupId,
   defaultValue,
+  // Emitted alongside `groupId` by remarkNpm; not a DOM/Tabs prop.
+  persist: _persist,
   children,
   ...props
 }: Omit<TabsProps, "defaultSelectedKey"> & {
   groupId?: string
   defaultValue?: string
+  persist?: boolean
 }) {
   const packageManager = packageManagerStore.useValue()
 


### PR DESCRIPTION
## Summary
- Restore `remarkNpmOptions.persist` in `www/source.config.ts`. It was dropped in the TanStack Start migration, so the ```npm tabs were emitted without a `groupId`, never bound to `packageManagerStore`, defaulted to npm, and forgot the user's choice. The install modals still passed `groupId` by hand, which is why those kept working.
- Strip the extra `persist` attribute fumadocs emits alongside `groupId` in `CodeBlockTabs` so it does not leak onto the DOM.
- Bump the `packageManager` pin to `pnpm@11.14.0` to match the corepack-installed version.

## Test plan
- [x] `/docs/installation` with no stored choice shows pnpm in both tab groups
- [x] Picking bun switches every install snippet on the page and stores `dotui-package-manager`
- [x] Choice survives a full reload and carries over to `/docs/components/field`
- [x] No console errors or unknown-prop warnings
- [x] `tsc --noEmit` and oxlint clean