### PR TITLE
feat(registry): ship preset fonts as registry:font items

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -36,9 +36,9 @@ One template only:
 pnpm smoke:examples --example spotify-tanstack-start
 ```
 
-Per template the script wipes generated files, runs `pnpm install`, `shadcn init <origin>/r/init?preset=…`, `shadcn add @dotui/<name>` for every item in `<origin>/r/registry.json`, then a production build and `tsc --noEmit`. After the build it also checks that every `@import url()` the theme appended to the stylesheet (Google Fonts) survived into the built CSS — bundlers drop a misplaced import silently instead of failing. The shadcn version is pinned in `scripts/smoke.ts`.
+Per template the script wipes generated files, runs `pnpm install`, `shadcn init <origin>/r/init?preset=…`, `shadcn add @dotui/<name>` for every item in `<origin>/r/registry.json`, then a production build and `tsc --noEmit`. After the build it also checks that every `@import url()` in the stylesheet survived into the built CSS (bundlers drop a misplaced import silently instead of failing), and, when the preset ships fonts, that the CLI wired them the framework's way — `next/font/google` in the Next.js root layout, an `@fontsource` import elsewhere — and that the faces made it into the built CSS. The shadcn version is pinned in `scripts/smoke.ts`.
 
-After a run you can `pnpm dev` inside a template to look at the result. The run also leaves each template's `package.json` modified — the CLI adds the components' npm dependencies to it, as it would in any project. `git checkout examples` resets the scaffolds.
+After a run you can `pnpm dev` inside a template to look at the result. The run also leaves each template's `package.json` modified (the CLI adds the components' npm dependencies) and, on Next.js with a preset that ships fonts, `src/app/layout.tsx` (the CLI wires `next/font/google` there), as it would in any project. `git checkout examples` resets the scaffolds.
 
 ## CI
 

--- a/examples/scripts/smoke.ts
+++ b/examples/scripts/smoke.ts
@@ -55,19 +55,30 @@ const EXAMPLES: Record<string, { framework: Framework; preset: string }> = {
 // and rewritten from this seed before every run. The `@source` is needed
 // because the installed components live in a gitignored folder, which
 // Tailwind v4 would otherwise skip when scanning for classes.
-const STYLESHEET: Record<
-  Framework,
-  { file: string; source: string; builtCss: string }
-> = {
+interface FrameworkSetup {
+  file: string
+  source: string
+  builtCss: string
+  /**
+   * Where `shadcn init` wires a `registry:font` item on this framework: the
+   * `next/font/google` import in the root layout on Next.js, the `@fontsource`
+   * import in the stylesheet elsewhere.
+   */
+  fontWiring: { file: string; needle: string }
+}
+
+const STYLESHEET: Record<Framework, FrameworkSetup> = {
   next: {
     file: "src/app/globals.css",
     source: "../components/ui",
     builtCss: ".next/static",
+    fontWiring: { file: "src/app/layout.tsx", needle: "next/font/google" },
   },
   "tanstack-start": {
     file: "src/styles.css",
     source: "./components/ui",
     builtCss: "dist/client",
+    fontWiring: { file: "src/styles.css", needle: '@import "@fontsource' },
   },
 }
 
@@ -160,13 +171,13 @@ function cssFiles(dir: string): string[] {
  */
 function checkBuiltCss(
   cwd: string,
-  stylesheet: { file: string; builtCss: string },
+  stylesheet: FrameworkSetup,
+  expectFonts: boolean,
 ): void {
   const source = readFileSync(path.join(cwd, stylesheet.file), "utf8")
   const urls = [...source.matchAll(/@import\s+url\(\s*['"]?([^'")]+)/g)].map(
     (m) => m[1]!,
   )
-  if (urls.length === 0) return
   const built = cssFiles(path.join(cwd, stylesheet.builtCss)).map((file) =>
     readFileSync(file, "utf8"),
   )
@@ -180,7 +191,33 @@ function checkBuiltCss(
         dropped.map((url) => `  ${url}`).join("\n"),
     )
   }
-  console.log(`@import url() survived the build: ${urls.length}`)
+  if (urls.length > 0) {
+    console.log(`@import url() survived the build: ${urls.length}`)
+  }
+
+  // A preset with fonts ships `registry:font` items; the CLI must have wired
+  // them the framework's way, and the faces must be in the built CSS.
+  if (!expectFonts) return
+  const { file, needle } = stylesheet.fontWiring
+  if (!readFileSync(path.join(cwd, file), "utf8").includes(needle)) {
+    throw new Error(`font not wired: ${file} has no ${needle}`)
+  }
+  if (!built.some((css) => css.includes("@font-face"))) {
+    throw new Error("font not wired: built CSS has no @font-face")
+  }
+  console.log(`fonts wired via ${needle}`)
+}
+
+/** Whether the init item for this preset pulls in `registry:font` items. */
+async function initHasFonts(
+  origin: string,
+  encodedPreset: string,
+): Promise<boolean> {
+  const url = `${origin}/r/init?preset=${encodedPreset}`
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`GET ${url} → ${res.status}`)
+  const item = (await res.json()) as { registryDependencies?: string[] }
+  return (item.registryDependencies ?? []).some((dep) => /\/r\/font-/.test(dep))
 }
 
 async function registryNames(origin: string): Promise<string[]> {
@@ -202,6 +239,7 @@ async function smoke(
   const { framework } = EXAMPLES[example]!
   const cwd = path.join(EXAMPLES_DIR, example)
   console.log(`\n=== ${example} ===`)
+  const expectFonts = await initHasFonts(origin, encodedPreset)
   for (const generated of GENERATED) {
     rmSync(path.join(cwd, generated), { recursive: true, force: true })
   }
@@ -230,7 +268,7 @@ async function smoke(
   // Next's next-env.d.ts).
   run(cwd, "pnpm", ["build"])
   run(cwd, "pnpm", ["typecheck"])
-  checkBuiltCss(cwd, stylesheet)
+  checkBuiltCss(cwd, stylesheet, expectFonts)
 }
 
 async function main() {

--- a/www/scripts/registry-probe.ts
+++ b/www/scripts/registry-probe.ts
@@ -37,8 +37,9 @@ const CONCURRENCY = 6
 // Hard per-request ceiling so a slow/blackholing host can't stretch the run
 // past undici's ~300s default headers timeout (× retries).
 const REQUEST_TIMEOUT_MS = 15_000
-// Extra names to probe that don't appear in registry.json's items list.
-const EXTRA_NAMES = ["init"]
+// Extra names to probe that don't appear in registry.json's items list: the
+// init item, and one `registry:font` item of the kind init depends on.
+const EXTRA_NAMES = ["init", "font-inter"]
 
 interface Failure {
   name: string

--- a/www/src/publisher/emit-font.test.ts
+++ b/www/src/publisher/emit-font.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  emitFontItem,
+  fontItemNamesForTokens,
+  parseFontItemName,
+} from "./emit-font"
+
+type FontItem = {
+  type: string
+  title?: string
+  font: {
+    family: string
+    provider: string
+    import: string
+    variable: string
+    subsets?: string[]
+    dependency?: string
+  }
+}
+
+describe("emitFontItem", () => {
+  test("body face: --font-sans, fontsource variable package, next/font import", () => {
+    const item = emitFontItem("font-figtree") as unknown as FontItem
+    expect(item.type).toBe("registry:font")
+    expect(item.title).toBe("Figtree")
+    expect(item.font).toMatchObject({
+      provider: "google",
+      import: "Figtree",
+      variable: "--font-sans",
+      subsets: ["latin"],
+      dependency: "@fontsource-variable/figtree",
+    })
+    // fontsource registers the variable face under "<Family> Variable".
+    expect(item.font.family).toMatch(/^'Figtree Variable', /)
+  })
+
+  test("heading and mono prefixes, multi-word families", () => {
+    const heading = emitFontItem(
+      "font-heading-source-sans-3",
+    ) as unknown as FontItem
+    expect(heading.title).toBe("Source Sans 3 (Heading)")
+    expect(heading.font.variable).toBe("--font-heading")
+    expect(heading.font.import).toBe("Source_Sans_3")
+    expect(heading.font.dependency).toBe("@fontsource-variable/source-sans-3")
+
+    const mono = emitFontItem("font-mono-jetbrains-mono") as unknown as FontItem
+    expect(mono.font.variable).toBe("--font-mono")
+    expect(mono.font.family).toMatch(/^'JetBrains Mono Variable', /)
+  })
+
+  test("unknown families and non-font names are not items", () => {
+    expect(emitFontItem("font-not-a-real-face")).toBeUndefined()
+    expect(emitFontItem("button")).toBeUndefined()
+    expect(parseFontItemName("font-heading-nope")).toBeUndefined()
+  })
+})
+
+describe("fontItemNamesForTokens", () => {
+  test("one item per font token, in token order, skipping unknown families", () => {
+    expect(
+      fontItemNamesForTokens({
+        "--font-mono": "'JetBrains Mono', ui-monospace, 'SF Mono', monospace",
+        "--font-sans": "'Figtree', ui-sans-serif, system-ui, sans-serif",
+        "--font-heading": "'Figtree', ui-sans-serif, system-ui, sans-serif",
+        "--radius": "1rem",
+      }),
+    ).toEqual([
+      "font-figtree",
+      "font-heading-figtree",
+      "font-mono-jetbrains-mono",
+    ])
+    expect(
+      fontItemNamesForTokens({ "--font-sans": "'Comic Sans MS', cursive" }),
+    ).toEqual([])
+  })
+})

--- a/www/src/publisher/emit-font.ts
+++ b/www/src/publisher/emit-font.ts
@@ -1,0 +1,112 @@
+/**
+ * `registry:font` items.
+ *
+ * shadcn installs a font per framework from one of these — on Next.js it wires
+ * `next/font/google` into the root layout, elsewhere it adds the `@fontsource`
+ * package and imports it — and sets the token's CSS variable either way. The
+ * init item references one per font token the preset sets (see emit-theme)
+ * instead of appending a Google Fonts `@import url()` to the consumer's
+ * stylesheet: shadcn's CSS updater inserts registry imports after
+ * `@import "tailwindcss"`, which is invalid once Tailwind expands, and
+ * bundlers drop it silently (the examples smoke caught this).
+ *
+ * Names follow shadcn's own registry: `font-<slug>` for the body face
+ * (`--font-sans`), `font-heading-<slug>` for `--font-heading`, plus
+ * `font-mono-<slug>` for `--font-mono`. Slugs double as the fontsource
+ * package names (`Source Sans 3` → `source-sans-3`).
+ */
+
+import {
+  familyFromStack,
+  FONT_CATALOG,
+  FONT_HEADING_VAR,
+  FONT_MONO_VAR,
+  FONT_SANS_VAR,
+  FONT_TOKEN_VARS,
+  fontStack,
+} from "@/lib/fonts"
+import type { RegistryItem } from "@/registry/types"
+
+type FontTokenVar = (typeof FONT_TOKEN_VARS)[number]
+
+const NAME_PREFIX: Record<FontTokenVar, string> = {
+  [FONT_SANS_VAR]: "font-",
+  [FONT_HEADING_VAR]: "font-heading-",
+  [FONT_MONO_VAR]: "font-mono-",
+}
+
+// Longest prefix first so `font-heading-x` never parses as the body face
+// `heading-x`.
+const PARSE_ORDER: FontTokenVar[] = [
+  FONT_HEADING_VAR,
+  FONT_MONO_VAR,
+  FONT_SANS_VAR,
+]
+
+const FAMILY_BY_SLUG = new Map(
+  FONT_CATALOG.map((font) => [fontSlug(font.family), font.family]),
+)
+
+export function fontSlug(family: string): string {
+  return family.toLowerCase().replaceAll(" ", "-")
+}
+
+export function fontItemName(variable: FontTokenVar, family: string): string {
+  return `${NAME_PREFIX[variable]}${fontSlug(family)}`
+}
+
+/** The font item each font token of a preset needs, in token order. */
+export function fontItemNamesForTokens(
+  tokens: Record<string, string>,
+): string[] {
+  const names: string[] = []
+  for (const variable of FONT_TOKEN_VARS) {
+    const stack = tokens[variable]
+    if (!stack) continue
+    const family = familyFromStack(stack)
+    if (!FAMILY_BY_SLUG.has(fontSlug(family))) continue
+    names.push(fontItemName(variable, family))
+  }
+  return names
+}
+
+export function parseFontItemName(
+  name: string,
+): { variable: FontTokenVar; family: string } | undefined {
+  for (const variable of PARSE_ORDER) {
+    const prefix = NAME_PREFIX[variable]
+    if (!name.startsWith(prefix)) continue
+    const family = FAMILY_BY_SLUG.get(name.slice(prefix.length))
+    return family ? { variable, family } : undefined
+  }
+  return undefined
+}
+
+export function emitFontItem(name: string): RegistryItem | undefined {
+  const parsed = parseFontItemName(name)
+  if (!parsed) return undefined
+  const { variable, family } = parsed
+  const role =
+    variable === FONT_HEADING_VAR
+      ? " (Heading)"
+      : variable === FONT_MONO_VAR
+        ? " (Mono)"
+        : ""
+  const item = {
+    name,
+    type: "registry:font",
+    title: `${family}${role}`,
+    font: {
+      // fontsource registers variable faces as "<Family> Variable"; next/font
+      // ignores `family` and sets the variable itself.
+      family: fontStack(family).replace(`'${family}'`, `'${family} Variable'`),
+      provider: "google",
+      // The `next/font/google` export: the family with spaces as underscores.
+      import: family.replaceAll(" ", "_"),
+      variable,
+      subsets: ["latin"],
+      dependency: `@fontsource-variable/${fontSlug(family)}`,
+    },
+  }
+  return item as unknown as RegistryItem
+}

--- a/www/src/publisher/emit-theme.test.ts
+++ b/www/src/publisher/emit-theme.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest"
 
 import type { RegistryItem } from "@/registry/types"
 
-import { emitInitItem } from "./emit-theme"
+import { emitInitItem, mergePresetCssFields } from "./emit-theme"
 
 type InitItemConfig = {
   config?: {
@@ -128,6 +128,43 @@ describe("emitInitItem", () => {
       "--btn-radius": "var(--radius-md)",
     })
     expect(baseRegistryCss.css[":root"]).not.toHaveProperty("--radius-factor") // legacy knob must stay gone
+  })
+
+  test("font tokens become registry:font deps, not a Google Fonts @import", () => {
+    const preset = {
+      density: "default" as const,
+      componentParams: {},
+      tokens: {
+        "--font-sans": "'Figtree', ui-sans-serif, system-ui, sans-serif",
+        "--font-heading": "'Figtree', ui-sans-serif, system-ui, sans-serif",
+      },
+    }
+    const item = emitInitItem({
+      baseRegistryCss,
+      preset,
+      registryRoot: "https://dotui.com",
+    })
+
+    expect(item.registryDependencies).toEqual([
+      "https://dotui.com/r/font-figtree",
+      "https://dotui.com/r/font-heading-figtree",
+    ])
+    // shadcn would place a CSS import after `@import "tailwindcss"`, where
+    // bundlers drop it — the faces travel as font items instead.
+    expect(
+      Object.keys(item.css ?? {}).some((key) => key.startsWith("@import url(")),
+    ).toBe(false)
+    // The `@theme` vocabulary still points at the family for the stack.
+    expect(item.cssVars?.theme?.["--font-sans"]).toMatch(/^'Figtree'/)
+
+    // The v0 export renders a real stylesheet and hoists imports, so it asks
+    // for the Google import explicitly.
+    const v0 = mergePresetCssFields(baseRegistryCss, preset, {
+      googleFontsImport: true,
+    })
+    expect(
+      Object.keys(v0.css ?? {}).find((key) => key.startsWith("@import url(")),
+    ).toMatch(/fonts\.googleapis\.com.*Figtree/)
   })
 
   test("a custom color recipe regenerates the :root + .dark primitive layer", () => {

--- a/www/src/publisher/emit-theme.ts
+++ b/www/src/publisher/emit-theme.ts
@@ -22,6 +22,7 @@ import {
 } from "@/registry/theme"
 import type { Density, RegistryItem } from "@/registry/types"
 
+import { fontItemNamesForTokens } from "./emit-font"
 import type { PublishPreset } from "./types"
 
 type RegistryCssFields = Pick<RegistryItem, "css" | "cssVars">
@@ -91,6 +92,12 @@ function emitPresetLightVars(preset: PublishPreset): Record<string, string> {
 export function emitInitItem(input: EmitThemeInput): RegistryItem {
   const { baseRegistryCss, preset, encodedPreset, registryRoot } = input
   const { css, cssVars } = mergePresetCssFields(baseRegistryCss, preset)
+  // One `registry:font` item per font token the preset sets. shadcn installs
+  // the face per framework (next/font on Next.js, @fontsource elsewhere) and
+  // sets the token variable — see emit-font.ts for why not a CSS `@import`.
+  const fontDependencies = fontItemNamesForTokens(preset.tokens ?? {}).map(
+    (name) => `${registryRoot}/r/${name}`,
+  )
 
   // Intentionally minimal `config` block:
   // - No `tailwind.css` or `tailwind.baseColor` — shadcn detects these from
@@ -129,8 +136,9 @@ export function emitInitItem(input: EmitThemeInput): RegistryItem {
     extends: "none",
     dependencies: DEFAULT_DEPENDENCIES,
     // shadcn's `cn` utils sit in a 4xx-gated path under v4 Tailwind, so we ship our own copy
-    // in `files[]` rather than declaring a registry dependency.
-    registryDependencies: [],
+    // in `files[]` rather than declaring a registry dependency. Fonts are the
+    // only registry deps here.
+    registryDependencies: fontDependencies,
     ...(css ? { css } : {}),
     ...(cssVars ? { cssVars } : {}),
     files: [
@@ -190,6 +198,16 @@ function chartVars(
 export function mergePresetCssFields(
   base: RegistryCssFields,
   preset: PublishPreset,
+  options: {
+    /**
+     * Ship the preset's Google-hosted faces as a CSS `@import url()`. Only for
+     * renderers that hoist `@import` keys to the top of a real stylesheet (the
+     * v0 globals.css). The init item ships `registry:font` items instead —
+     * shadcn's CSS updater would place this import after `@import
+     * "tailwindcss"`, where bundlers drop it.
+     */
+    googleFontsImport?: boolean
+  } = {},
 ): RegistryCssFields {
   const css = cloneRecord(base.css) ?? {}
   mergeCssVarsIntoCssRule(css, ":root", base.cssVars?.light)
@@ -242,16 +260,17 @@ export function mergePresetCssFields(
 
   // Typography: re-point the `@theme` vocabulary at the preset's stacks (the
   // block renders `@theme inline`, so utilities bake these values in — a
-  // `:root` override wouldn't reach them), and ship the Google-hosted faces
-  // with a plain CSS import (the v0 globals renderer hoists `@import` keys,
-  // shadcn's CSS updater passes at-rule keys through).
+  // `:root` override wouldn't reach them). The faces themselves come from
+  // `registry:font` items (init) or, on request, a Google Fonts import (v0).
   for (const varName of FONT_TOKEN_VARS) {
     const stack = preset.tokens?.[varName]
     if (stack) themeVars[varName] = stack
   }
-  const fontFamilies = fontFamiliesFromTokens(preset.tokens ?? {})
-  if (fontFamilies.length > 0) {
-    css[`@import url('${googleFontsUrl(fontFamilies)}')`] = {}
+  if (options.googleFontsImport) {
+    const fontFamilies = fontFamiliesFromTokens(preset.tokens ?? {})
+    if (fontFamilies.length > 0) {
+      css[`@import url('${googleFontsUrl(fontFamilies)}')`] = {}
+    }
   }
 
   return {

--- a/www/src/routes/r/$name.tsx
+++ b/www/src/routes/r/$name.tsx
@@ -8,7 +8,8 @@
  *   - scalar param values (rewritten inline into Tailwind suffixes)
  *   - enum-with-files choices (e.g. loader.style = "ring" → ship base.ring.tsx)
  *
- * `name` must match a generated publishable. Missing names return 404.
+ * `name` must match a generated publishable, or a `font-*` item name (see
+ * publisher/emit-font). Missing names return 404.
  */
 
 import { createFileRoute } from "@tanstack/react-router"
@@ -30,6 +31,7 @@ import {
 setKnownDotuiNames(PUBLISHABLE_NAMES)
 
 import { resolveRequestPreset } from "@/lib/registry-preset"
+import { emitFontItem } from "@/publisher/emit-font"
 
 const JSON_HEADERS = {
   "Content-Type": "application/json; charset=utf-8",
@@ -47,6 +49,19 @@ export const Route = createFileRoute("/r/$name")({
     handlers: {
       GET: async ({ request, params }) => {
         const name = params.name
+
+        // `font-*` names are `registry:font` items the init item depends on;
+        // preset-independent, no publishable behind them.
+        if (name.startsWith("font-")) {
+          const fontItem = emitFontItem(name)
+          if (!fontItem) {
+            return Response.json({ error: "Not found" }, { status: 404 })
+          }
+          return new Response(JSON.stringify(fontItem, null, 2), {
+            headers: JSON_HEADERS,
+          })
+        }
+
         const loader = publishables[name]
         if (!loader) {
           return Response.json({ error: "Not found" }, { status: 404 })

--- a/www/src/routes/r/v0.tsx
+++ b/www/src/routes/r/v0.tsx
@@ -65,7 +65,9 @@ export const Route = createFileRoute("/r/v0")({
 
         const item = buildV0Item({
           items,
-          cssFields: mergePresetCssFields(baseRegistryCss, preset),
+          cssFields: mergePresetCssFields(baseRegistryCss, preset, {
+            googleFontsImport: true,
+          }),
           supportFiles: SUPPORT_FILES,
         })
 


### PR DESCRIPTION
Stacked on #707 (base branch `examples-consumers`); retarget once that merges. Turns the Spotify templates green.

## Summary

- Presets with a font shipped the face as a Google Fonts `@import url()` in the init item's `css`. shadcn's CSS updater inserts registry imports after the last existing one — after `@import "tailwindcss"` — so once Tailwind expands, the import sits after rules and is invalid. `next dev` fails to compile; `next build` and `vite build` succeed and silently drop it, so consumers got the theme without its font. The `emit-theme.ts` comment assumed the updater keeps the import at the top.
- The init item now depends on `registry:font` items instead, one per font token the preset sets (`--font-sans`, `--font-heading`, `--font-mono`), and the CLI installs the face the framework's way: `next/font/google` wired into the root layout on Next.js, the `@fontsource-variable` package plus its import elsewhere. Self-hosted either way; no runtime request to Google.
- New `publisher/emit-font.ts` builds the items from the font catalog; `/r/$name` serves `font-*` names from it. Naming follows shadcn's own registry (`font-<slug>`, `font-heading-<slug>`, plus `font-mono-<slug>`), and slugs double as fontsource package names.
- The v0 export renders a real stylesheet and hoists its imports, so it keeps the Google import via an explicit `mergePresetCssFields(…, { googleFontsImport: true })`.
- The examples smoke now also asserts, for presets that ship fonts, that the CLI wired them (`next/font/google` in the Next layout, `@import "@fontsource…"` in the stylesheet elsewhere) and that `@font-face` rules made it into the built CSS. The production probe fetches one font endpoint too.

## Verification

All four templates green against this branch's dev server, including the two Spotify ones that were red on #707. Served output for the Spotify preset: `registryDependencies: ["…/r/font-figtree"]`, no `@import url(` key, `--font-sans` still points at the family in `@theme`; `/r/font-figtree` returns the item, `/r/font-nope` is 404; the v0 globals still carry the Google import.

`pnpm check`, `pnpm typecheck`, `pnpm test` (publisher: 94, incl. new emit-font tests and an init/v0 split test) pass.

## Notes

- fontsource publishes a `@fontsource-variable/<slug>` package for Google's variable families, which is what the catalog holds. A family without one would fail the consumer's install on non-Next frameworks; none are known, and the smoke would catch it.
- On Next.js the CLI edits `src/app/layout.tsx` to add the font, so a smoke run leaves that file modified in the Next templates alongside `package.json`. Documented in `examples/README.md`.
