### PR TITLE
fix(docs): align demo controls close button with its trigger

### DIFF
--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -172,7 +172,7 @@ export function InteractiveDemo({
               controlsOpen ? "h-auto" : "h-56",
             )}
           >
-            <div className="flex flex-col gap-4 px-5 pt-3 pb-5">
+            <div className="flex flex-col gap-4 px-4 pt-2 pb-4">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium text-fg-muted">
                   Controls


### PR DESCRIPTION
## What

In interactive demos, the controls panel padding goes from `px-5 pt-3 pb-5` to `px-4 pt-2 pb-4`.

## Why

The open-controls trigger is pinned at `top-2 right-2`. The close button inside the panel sat at 12px/12px, so the two buttons didn't overlap when the panel toggled. With the reduced padding (and the close button's existing `-mr-2`), both `sm` icon buttons now land at exactly 8px from the top and right.