### PR TITLE
feat(studio): dev tweak to hide the panel WIP chips

### DIFF
--- a/www/src/modules/panel-lab/drill-in.tsx
+++ b/www/src/modules/panel-lab/drill-in.tsx
@@ -159,6 +159,8 @@ export function DrillInPanel({
   const index = resolveIndex(chapters)
   const [activeId, setActiveId] = useState<string | null>(null)
   // Dev tweak: hide the chips to read the panel as the finished product.
+  // Deliberately kept (not exploration scaffolding) — it goes when the last
+  // chip drops at the parity bar (issue #666).
   const showWip = useTweak("WIP chips", {
     type: "boolean",
     default: true,

--- a/www/src/modules/panel-lab/drill-in.tsx
+++ b/www/src/modules/panel-lab/drill-in.tsx
@@ -25,7 +25,7 @@ import type { PanelSystem } from "./panel"
 import { ControlGroup, GroupTitle, ROW_LABEL } from "./rows"
 import { PanelSearch } from "./search"
 import type { Chapter, Lab } from "./state"
-import { isWired } from "./wired"
+import { showWip } from "./wired"
 
 const PANE =
   "absolute inset-0 no-scrollbar flex flex-col overflow-y-auto overscroll-contain px-3 pt-[56px] pb-[64px] *:shrink-0"
@@ -62,7 +62,7 @@ function IndexRow({
 }) {
   const status = lab.section(chapter.defaults)
   const Demo = CARD_DEMOS[chapter.id]
-  const wip = !isWired(chapter.members.map((m) => m.id)) && <WipChip />
+  const wip = showWip(chapter.members.map((m) => m.id)) && <WipChip />
   // The label column: title (with its modified dot), and the live value
   // beneath it — first segment only, one word-ish.
   const label = (
@@ -229,7 +229,7 @@ export function DrillInPanel({
                   All settings
                 </RacButton>
                 <span className="ml-auto flex items-center gap-1.5 pr-1">
-                  {!isWired(page.members.map((m) => m.id)) && <WipChip />}
+                  {showWip(page.members.map((m) => m.id)) && <WipChip />}
                   <span className="text-[0.8125rem] font-medium text-fg">
                     {page.label}
                   </span>

--- a/www/src/modules/panel-lab/drill-in.tsx
+++ b/www/src/modules/panel-lab/drill-in.tsx
@@ -16,6 +16,7 @@ import { ChevronLeftIcon } from "lucide-react"
 import { Button as RacButton } from "react-aria-components"
 
 import { cn } from "@/registry/lib/utils"
+import { useTweak } from "@/dev/tweaker"
 
 import { CARD_DEMOS } from "./demos"
 import { resolveIndex } from "./groups"
@@ -25,7 +26,7 @@ import type { PanelSystem } from "./panel"
 import { ControlGroup, GroupTitle, ROW_LABEL } from "./rows"
 import { PanelSearch } from "./search"
 import type { Chapter, Lab } from "./state"
-import { showWip } from "./wired"
+import { isWired } from "./wired"
 
 const PANE =
   "absolute inset-0 no-scrollbar flex flex-col overflow-y-auto overscroll-contain px-3 pt-[56px] pb-[64px] *:shrink-0"
@@ -53,16 +54,20 @@ function IndexRow({
   chapter,
   lab,
   compact,
+  showWip,
   onPress,
 }: {
   chapter: IndexChapter
   lab: Lab
   compact?: boolean
+  showWip: boolean
   onPress: () => void
 }) {
   const status = lab.section(chapter.defaults)
   const Demo = CARD_DEMOS[chapter.id]
-  const wip = showWip(chapter.members.map((m) => m.id)) && <WipChip />
+  const wip = showWip && !isWired(chapter.members.map((m) => m.id)) && (
+    <WipChip />
+  )
   // The label column: title (with its modified dot), and the live value
   // beneath it — first segment only, one word-ish.
   const label = (
@@ -153,6 +158,12 @@ export function DrillInPanel({
 }) {
   const index = resolveIndex(chapters)
   const [activeId, setActiveId] = useState<string | null>(null)
+  // Dev tweak: hide the chips to read the panel as the finished product.
+  const showWip = useTweak("WIP chips", {
+    type: "boolean",
+    default: true,
+    group: "Studio panel",
+  })
   const page =
     index
       .flatMap((group) => group.chapters)
@@ -204,6 +215,7 @@ export function DrillInPanel({
                   chapter={chapter}
                   lab={lab}
                   compact={group.compact}
+                  showWip={showWip}
                   onPress={() => setActiveId(chapter.id)}
                 />
               ))}
@@ -229,7 +241,9 @@ export function DrillInPanel({
                   All settings
                 </RacButton>
                 <span className="ml-auto flex items-center gap-1.5 pr-1">
-                  {showWip(page.members.map((m) => m.id)) && <WipChip />}
+                  {showWip && !isWired(page.members.map((m) => m.id)) && (
+                    <WipChip />
+                  )}
                   <span className="text-[0.8125rem] font-medium text-fg">
                     {page.label}
                   </span>

--- a/www/src/modules/panel-lab/wired.ts
+++ b/www/src/modules/panel-lab/wired.ts
@@ -1,13 +1,10 @@
 /* Chapters whose values actually drive the preview and export. Everything
-   else wears a WIP chip — on production only, so previews and dev read as
-   the finished panel. Add a chapter's id here in the PR that wires it
+   else wears a WIP chip. Add a chapter's id here in the PR that wires it
    (issue #666); a composite index card drops its chip once every member is
    wired. */
 
 export const WIRED_CHAPTERS = new Set<string>([])
 
-const SHOW_WIP = import.meta.env.VERCEL_ENV === "production"
-
-export function showWip(memberIds: string[]): boolean {
-  return SHOW_WIP && !memberIds.every((id) => WIRED_CHAPTERS.has(id))
+export function isWired(memberIds: string[]): boolean {
+  return memberIds.every((id) => WIRED_CHAPTERS.has(id))
 }

--- a/www/src/modules/panel-lab/wired.ts
+++ b/www/src/modules/panel-lab/wired.ts
@@ -1,10 +1,13 @@
 /* Chapters whose values actually drive the preview and export. Everything
-   else wears a WIP chip. Add a chapter's id here in the PR that wires it
+   else wears a WIP chip — on production only, so previews and dev read as
+   the finished panel. Add a chapter's id here in the PR that wires it
    (issue #666); a composite index card drops its chip once every member is
    wired. */
 
 export const WIRED_CHAPTERS = new Set<string>([])
 
-export function isWired(memberIds: string[]): boolean {
-  return memberIds.every((id) => WIRED_CHAPTERS.has(id))
+const SHOW_WIP = import.meta.env.VERCEL_ENV === "production"
+
+export function showWip(memberIds: string[]): boolean {
+  return SHOW_WIP && !memberIds.every((id) => WIRED_CHAPTERS.has(id))
 }


### PR DESCRIPTION
## What

Adds a **WIP chips** switch to the dev tweaker (group "Studio panel") that hides the not-wired-yet chips in the /studio panel. It defaults to on, so the chip contract from CLAUDE.md (a chapter carries a chip until wired) holds everywhere; the switch is only there to read the panel as the finished product while iterating.

## How

- `panel-lab/drill-in.tsx`: `DrillInPanel` reads `useTweak("WIP chips", { type: "boolean", default: true })` once and threads `showWip` to the index rows and the chapter-page header.
- `useTweak` is a no-op in production, so production always shows the chips and the tweaker tree-shakes away.

## Notes

Earlier revision gated the chips on `VERCEL_ENV === "production"`; reverted after review since that hid wiring status exactly where PRs are reviewed. `pnpm check` and `pnpm typecheck` pass.