### PR TITLE
feat(www): rework hero for mobile, copy, and stack logos

### DIFF
--- a/www/src/modules/marketing/hero-stack.tsx
+++ b/www/src/modules/marketing/hero-stack.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useLayoutEffect, useRef, useState } from "react"
+import { Tooltip } from "@base-ui/react/tooltip"
+import { AnimatePresence, motion, useReducedMotion } from "motion/react"
+
+import { ReactAriaIcon } from "@/components/icons/react-aria"
+import { ShadcnIcon } from "@/components/icons/shadcn"
+import { TailwindIcon } from "@/components/icons/tailwind"
+
+const tools = [
+  {
+    label: "Built on React Aria",
+    href: "https://react-spectrum.adobe.com/react-aria",
+    icon: <ReactAriaIcon className="size-5" />,
+  },
+  {
+    label: "Styled with Tailwind",
+    href: "https://tailwindcss.com",
+    icon: <TailwindIcon className="size-8 text-[#38bdf8]" />,
+  },
+  {
+    label: "Installed via shadcn CLI",
+    href: "https://ui.shadcn.com",
+    icon: <ShadcnIcon className="size-6" />,
+  },
+]
+
+const handle = Tooltip.createHandle<string>()
+
+const logoClass =
+  "box-content flex size-8 items-center justify-center px-1.5 py-1 opacity-50 grayscale transition-[opacity,filter] duration-200 hover:opacity-100 hover:grayscale-0 focus-visible:opacity-100 focus-visible:grayscale-0 outline-none"
+
+const EASE_OUT = [0.16, 1, 0.3, 1] as const // easeOutExpo — arrival
+const EASE_IN = [0.55, 0.055, 0.675, 0.19] as const // easeInCubic — departure
+const ENTER = 0.18
+const EXIT = 0.12
+const SHIFT = 6
+const BLUR = "blur(3px)"
+
+// The label shifts along the pointer's direction, so text and popup travel read as one move.
+const VARIANTS = {
+  initial: (dir: number) => ({ opacity: 0, filter: BLUR, x: SHIFT * dir }),
+  animate: { opacity: 1, filter: "blur(0px)", x: 0 },
+  exit: (dir: number) => ({
+    opacity: 0,
+    filter: BLUR,
+    x: -SHIFT * dir,
+    transition: { duration: EXIT, ease: EASE_IN },
+  }),
+}
+
+const REDUCED_VARIANTS = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0, transition: { duration: EXIT } },
+}
+
+function TipLabel({ label, dir }: { label: string; dir: number }) {
+  const reduce = useReducedMotion() ?? false
+  const variants = reduce ? REDUCED_VARIANTS : VARIANTS
+  const measure = useRef<HTMLSpanElement>(null)
+  const [width, setWidth] = useState<number>()
+  useLayoutEffect(() => {
+    setWidth(measure.current?.offsetWidth)
+  }, [label])
+  return (
+    <motion.div
+      className="relative overflow-hidden whitespace-nowrap"
+      initial={false}
+      animate={{ width }}
+      transition={reduce ? { duration: 0 } : { duration: 0.2, ease: EASE_OUT }}
+    >
+      <span ref={measure} aria-hidden className="invisible block w-max">
+        {label}
+      </span>
+      <AnimatePresence initial={false} custom={dir}>
+        <motion.span
+          key={label}
+          custom={dir}
+          className="absolute inset-0"
+          variants={variants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          transition={{ duration: ENTER, ease: EASE_OUT }}
+        >
+          {label}
+        </motion.span>
+      </AnimatePresence>
+    </motion.div>
+  )
+}
+
+function SharedTooltip() {
+  // Ref, not state: render runs more than once per payload, so derive dir only on change.
+  const prev = useRef({ index: 0, dir: 1 })
+  return (
+    <Tooltip.Root handle={handle}>
+      {({ payload }) => {
+        const index = tools.findIndex((tool) => tool.label === payload)
+        if (index !== -1 && index !== prev.current.index) {
+          prev.current = { index, dir: Math.sign(index - prev.current.index) }
+        }
+        const dir = prev.current.dir
+        return (
+          <Tooltip.Portal>
+            <Tooltip.Positioner
+              side="bottom"
+              sideOffset={6}
+              className="transition-transform duration-200 ease-out"
+            >
+              <Tooltip.Popup className="rounded-(--tooltip-radius) border border-border bg-neutral px-3 py-1.5 text-xs text-fg-on-neutral shadow-[var(--shadow-overlay,none)] transition-[opacity,scale] duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+                <TipLabel label={payload ?? ""} dir={dir} />
+              </Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        )
+      }}
+    </Tooltip.Root>
+  )
+}
+
+function Logo({ tool }: { tool: (typeof tools)[number] }) {
+  return (
+    <Tooltip.Trigger
+      handle={handle}
+      payload={tool.label}
+      delay={0}
+      render={<a href={tool.href} target="_blank" rel="noreferrer" />}
+      aria-label={tool.label}
+      className={logoClass}
+    >
+      {tool.icon}
+    </Tooltip.Trigger>
+  )
+}
+
+export function HeroStack() {
+  return (
+    <div className="mt-6 flex items-center">
+      {tools.map((tool) => (
+        <Logo key={tool.label} tool={tool} />
+      ))}
+      <SharedTooltip />
+    </div>
+  )
+}

--- a/www/src/modules/marketing/hero-stack.tsx
+++ b/www/src/modules/marketing/hero-stack.tsx
@@ -10,21 +10,34 @@ import { TailwindIcon } from "@/components/icons/tailwind"
 
 const tools = [
   {
-    label: "Built on React Aria",
+    prefix: "Built on",
+    name: "React Aria",
     href: "https://react-spectrum.adobe.com/react-aria",
     icon: <ReactAriaIcon className="size-5" />,
   },
   {
-    label: "Styled with Tailwind",
+    prefix: "Styled with",
+    name: "Tailwind",
     href: "https://tailwindcss.com",
     icon: <TailwindIcon className="size-8 text-[#38bdf8]" />,
   },
   {
-    label: "Installed via shadcn CLI",
+    prefix: "Installed via",
+    name: "shadcn CLI",
     href: "https://ui.shadcn.com",
     icon: <ShadcnIcon className="size-6" />,
   },
-]
+].map((tool) => ({ ...tool, label: `${tool.prefix} ${tool.name}` }))
+
+type Tool = (typeof tools)[number]
+
+function Label({ tool }: { tool: Tool }) {
+  return (
+    <>
+      {tool.prefix} <span className="font-medium">{tool.name}</span>
+    </>
+  )
+}
 
 const handle = Tooltip.createHandle<string>()
 
@@ -56,14 +69,14 @@ const REDUCED_VARIANTS = {
   exit: { opacity: 0, transition: { duration: EXIT } },
 }
 
-function TipLabel({ label, dir }: { label: string; dir: number }) {
+function TipLabel({ tool, dir }: { tool: Tool; dir: number }) {
   const reduce = useReducedMotion() ?? false
   const variants = reduce ? REDUCED_VARIANTS : VARIANTS
   const measure = useRef<HTMLSpanElement>(null)
   const [width, setWidth] = useState<number>()
   useLayoutEffect(() => {
     setWidth(measure.current?.offsetWidth)
-  }, [label])
+  }, [tool])
   return (
     <motion.div
       className="relative overflow-hidden whitespace-nowrap"
@@ -72,11 +85,11 @@ function TipLabel({ label, dir }: { label: string; dir: number }) {
       transition={reduce ? { duration: 0 } : { duration: 0.2, ease: EASE_OUT }}
     >
       <span ref={measure} aria-hidden className="invisible block w-max">
-        {label}
+        <Label tool={tool} />
       </span>
       <AnimatePresence initial={false} custom={dir}>
         <motion.span
-          key={label}
+          key={tool.label}
           custom={dir}
           className="absolute inset-0"
           variants={variants}
@@ -85,7 +98,7 @@ function TipLabel({ label, dir }: { label: string; dir: number }) {
           exit="exit"
           transition={{ duration: ENTER, ease: EASE_OUT }}
         >
-          {label}
+          <Label tool={tool} />
         </motion.span>
       </AnimatePresence>
     </motion.div>
@@ -102,7 +115,9 @@ function SharedTooltip() {
         if (index !== -1 && index !== prev.current.index) {
           prev.current = { index, dir: Math.sign(index - prev.current.index) }
         }
-        const dir = prev.current.dir
+        const { dir } = prev.current
+        const tool = tools[prev.current.index]
+        if (!tool) return null
         return (
           <Tooltip.Portal>
             <Tooltip.Positioner
@@ -111,7 +126,7 @@ function SharedTooltip() {
               className="transition-transform duration-200 ease-out"
             >
               <Tooltip.Popup className="rounded-(--tooltip-radius) border border-border bg-neutral px-3 py-1.5 text-xs text-fg-on-neutral shadow-[var(--shadow-overlay,none)] transition-[opacity,scale] duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
-                <TipLabel label={payload ?? ""} dir={dir} />
+                <TipLabel tool={tool} dir={dir} />
               </Tooltip.Popup>
             </Tooltip.Positioner>
           </Tooltip.Portal>
@@ -121,7 +136,7 @@ function SharedTooltip() {
   )
 }
 
-function Logo({ tool }: { tool: (typeof tools)[number] }) {
+function Logo({ tool }: { tool: Tool }) {
   return (
     <Tooltip.Trigger
       handle={handle}

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -28,7 +28,7 @@ export function HomePage() {
         <section className="flex flex-col pt-10 sm:pt-14 md:pt-20">
           <div className="flex flex-col items-center text-center">
             <HeroEyebrow />
-            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/10.3),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
+            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.625rem,calc((100vw-2rem)/10.7),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
               The Design System Studio
               <br />
               <span className="text-fg-muted">

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -35,8 +35,8 @@ export function HomePage() {
               </span>
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-              Every design decision is yours — create, tweak, and ship code you
-              own.
+              Every design decision is yours. Create, tweak, and ship components
+              you own.
               {/* Once a non-web export ships: One foundation for all platforms. */}
             </p>
             <div className="mt-9 flex items-center gap-3">

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -28,14 +28,14 @@ export function HomePage() {
         <section className="flex flex-col pt-10 sm:pt-14 md:pt-20">
           <div className="flex flex-col items-center text-center">
             <HeroEyebrow />
-            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.5rem,calc((100vw-2rem)/12.6),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
+            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.5rem,calc((100vw-2rem)/11.7),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
               The Design System Studio
               <br />
               <span className="text-fg-muted">
                 for <HeroWordSwap />
               </span>
             </h1>
-            <p className="mt-5 max-w-2xl text-base leading-relaxed text-balance text-fg-muted sm:text-lg">
+            <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
               Every design decision is yours — create, tweak, and ship code you
               own.
               {/* Once a non-web export ships: One foundation for all platforms. */}

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -35,8 +35,9 @@ export function HomePage() {
               </span>
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-              Every design decision is yours. Create, tweak, and ship components
-              you own.
+              Every design decision is yours. Create, tweak and refine colors,
+              type and components live, then install them with the shadcn CLI as
+              React code you own.
               {/* Once a non-web export ships: One foundation for all platforms. */}
             </p>
             <div className="mt-9 flex items-center gap-3">

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -1,21 +1,19 @@
 import { LinkButton } from "@/registry/ui/button"
-import { Eyebrow } from "@/components/eyebrow"
-import { ReactAriaIcon } from "@/components/icons/react-aria"
-import { TailwindIcon } from "@/components/icons/tailwind"
 import { Footer } from "@/components/layout/footer"
 import Cards from "@/modules/marketing/cards"
 import { CtaSection } from "@/modules/marketing/cta-section"
 import { HeroWordSwap } from "@/modules/marketing/hero-word-swap"
 
-function HeroEyebrow() {
+function StackLink({ href, children }: { href: string; children: string }) {
   return (
-    <Eyebrow className="mb-3 border-transparent bg-inverse/5 pl-2.5">
-      <span aria-hidden className="relative flex size-1.5">
-        <span className="absolute inset-0 animate-ping rounded-full bg-warning opacity-75" />
-        <span className="relative size-1.5 rounded-full bg-warning" />
-      </span>
-      Public preview
-    </Eyebrow>
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="underline decoration-fg-muted/40 underline-offset-3 hover:text-fg"
+    >
+      {children}
+    </a>
   )
 }
 
@@ -29,7 +27,6 @@ export function HomePage() {
         {/* Hero section */}
         <section className="flex flex-col pt-10 sm:pt-14 md:pt-20">
           <div className="flex flex-col items-center text-center">
-            <HeroEyebrow />
             <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/8.5),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
               The Design System Studio <br className="max-sm:hidden" />
               <span className="text-fg-muted">
@@ -38,7 +35,7 @@ export function HomePage() {
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
               Every design decision is yours. Create, tweak and refine your
-              system live, then install it with the shadcn CLI as code you own.
+              system live. Install it with shadcn CLI as code you own.
               {/* Once a non-web export ships: One foundation for all platforms. */}
             </p>
             <div className="mt-9 flex items-center gap-3">
@@ -49,16 +46,14 @@ export function HomePage() {
                 View components
               </LinkButton>
             </div>
-            <p className="mt-6 flex items-center gap-x-4 text-sm text-fg-muted">
-              <span>Built on</span>
-              <span className="inline-flex items-center gap-1.5">
-                <ReactAriaIcon className="size-4" />
+            <p className="mt-6 text-sm text-balance text-fg-muted">
+              Currently in beta · Built on{" "}
+              <StackLink href="https://react-spectrum.adobe.com/react-aria">
                 React Aria
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <TailwindIcon className="size-4" />
-                Tailwind CSS
-              </span>
+              </StackLink>
+              , <StackLink href="https://base-ui.com">Base UI</StackLink> and{" "}
+              <StackLink href="https://tailwindcss.com">Tailwind CSS</StackLink>
+              .
             </p>
           </div>
         </section>

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -35,7 +35,7 @@ export function HomePage() {
                 for <HeroWordSwap />
               </span>
             </h1>
-            <p className="mt-5 max-w-2xl text-base leading-relaxed sm:text-lg text-balance text-fg-muted">
+            <p className="mt-5 max-w-2xl text-base leading-relaxed text-balance text-fg-muted sm:text-lg">
               Every design decision is yours — create, tweak, and ship code you
               own.
               {/* Once a non-web export ships: One foundation for all platforms. */}

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -28,9 +28,8 @@ export function HomePage() {
         <section className="flex flex-col pt-10 sm:pt-14 md:pt-20">
           <div className="flex flex-col items-center text-center">
             <HeroEyebrow />
-            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.5rem,calc((100vw-2rem)/11.7),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
-              The Design System Studio
-              <br />
+            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/8.5),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
+              The Design System Studio <br className="max-sm:hidden" />
               <span className="text-fg-muted">
                 for <HeroWordSwap />
               </span>

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -1,5 +1,7 @@
 import { LinkButton } from "@/registry/ui/button"
 import { Eyebrow } from "@/components/eyebrow"
+import { ReactAriaIcon } from "@/components/icons/react-aria"
+import { TailwindIcon } from "@/components/icons/tailwind"
 import { Footer } from "@/components/layout/footer"
 import Cards from "@/modules/marketing/cards"
 import { CtaSection } from "@/modules/marketing/cta-section"
@@ -35,9 +37,8 @@ export function HomePage() {
               </span>
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-              Every design decision is yours. Create, tweak and refine colors,
-              type and components live, then install them with the shadcn CLI as
-              React code you own.
+              Every design decision is yours. Create, tweak and refine your
+              system live, then install it with the shadcn CLI as code you own.
               {/* Once a non-web export ships: One foundation for all platforms. */}
             </p>
             <div className="mt-9 flex items-center gap-3">
@@ -48,6 +49,17 @@ export function HomePage() {
                 View components
               </LinkButton>
             </div>
+            <p className="mt-6 flex items-center gap-x-4 text-sm text-fg-muted">
+              <span>Built on</span>
+              <span className="inline-flex items-center gap-1.5">
+                <ReactAriaIcon className="size-4" />
+                React Aria
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <TailwindIcon className="size-4" />
+                Tailwind CSS
+              </span>
+            </p>
           </div>
         </section>
 

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -28,14 +28,14 @@ export function HomePage() {
         <section className="flex flex-col pt-10 sm:pt-14 md:pt-20">
           <div className="flex flex-col items-center text-center">
             <HeroEyebrow />
-            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.625rem,calc((100vw-2rem)/10.7),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
+            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.5rem,calc((100vw-2rem)/12.6),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
               The Design System Studio
               <br />
               <span className="text-fg-muted">
                 for <HeroWordSwap />
               </span>
             </h1>
-            <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
+            <p className="mt-5 max-w-2xl text-base leading-relaxed sm:text-lg text-balance text-fg-muted">
               Every design decision is yours — create, tweak, and ship code you
               own.
               {/* Once a non-web export ships: One foundation for all platforms. */}

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -47,7 +47,7 @@ export function HomePage() {
           </div>
         </section>
 
-        <section className="mt-28 md:mt-32">
+        <section className="mt-24 md:mt-28">
           <Cards />
         </section>
 

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -1,19 +1,16 @@
 import { LinkButton } from "@/registry/ui/button"
+import { Eyebrow } from "@/components/eyebrow"
 import { Footer } from "@/components/layout/footer"
 import Cards from "@/modules/marketing/cards"
 import { CtaSection } from "@/modules/marketing/cta-section"
+import { HeroStack } from "@/modules/marketing/hero-stack"
 import { HeroWordSwap } from "@/modules/marketing/hero-word-swap"
 
-function StackLink({ href, children }: { href: string; children: string }) {
+function HeroEyebrow() {
   return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      className="underline decoration-fg-muted/40 underline-offset-3 hover:text-fg"
-    >
-      {children}
-    </a>
+    <Eyebrow className="mb-3 border-transparent bg-inverse/5">
+      Currently in beta
+    </Eyebrow>
   )
 }
 
@@ -27,6 +24,7 @@ export function HomePage() {
         {/* Hero section */}
         <section className="flex flex-col pt-10 sm:pt-14 md:pt-20">
           <div className="flex flex-col items-center text-center">
+            <HeroEyebrow />
             <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/8.5),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
               The Design System Studio <br className="max-sm:hidden" />
               <span className="text-fg-muted">
@@ -34,8 +32,7 @@ export function HomePage() {
               </span>
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-              Every design decision is yours. Create, tweak and refine your
-              system live. Install it with shadcn CLI as code you own.
+              Every design decision is yours. Create, refine and own the code.
               {/* Once a non-web export ships: One foundation for all platforms. */}
             </p>
             <div className="mt-9 flex items-center gap-3">
@@ -46,19 +43,11 @@ export function HomePage() {
                 View components
               </LinkButton>
             </div>
-            <p className="mt-6 text-sm text-balance text-fg-muted">
-              Currently in beta · Built on{" "}
-              <StackLink href="https://react-spectrum.adobe.com/react-aria">
-                React Aria
-              </StackLink>
-              , <StackLink href="https://base-ui.com">Base UI</StackLink> and{" "}
-              <StackLink href="https://tailwindcss.com">Tailwind CSS</StackLink>
-              .
-            </p>
+            <HeroStack />
           </div>
         </section>
 
-        <section className="mt-24">
+        <section className="mt-28 md:mt-32">
           <Cards />
         </section>
 


### PR DESCRIPTION
## Summary

**Hero title on mobile**
- Below `sm` the forced line break is hidden and `text-balance` wraps the heading into two even lines: "The Design System" / "Studio for humans". The font-size clamp is raised (`clamp(1.75rem, calc((100vw - 2rem) / 8.5), 3rem)`) so the longer line lands at ~90% of the content width. Desktop is unchanged.

**Copy**
- Eyebrow: "Public preview" with the pulsing dot → "Currently in beta", no dot.
- Description: "Every design decision is yours — create, tweak, and ship code you own." → "Every design decision is yours. Create, refine and own the code."

**Stack logos** (`hero-stack.tsx`)
- Under the CTAs, three logo links: React Aria, Tailwind, shadcn. Grey and dimmed at rest, full colour on hover/focus. Same 44×40 hit box for each, icons sized individually so they read at the same weight.
- One shared tooltip (Base UI `Tooltip.createHandle`) instead of three: it opens instantly, sits below the logos, and slides between triggers while its label crossfades. The label shifts 6px along the pointer's direction with a 3px blur; 180ms ease-out in, 120ms ease-in out; width tweens to the new label. Reduced motion drops blur and travel.
- Labels: "Built on React Aria", "Styled with Tailwind", "Installed via shadcn CLI". Tool names are medium weight; tooltip uses the neutral surface.

**Spacing**
- Gap between the hero and the components showcase: 6rem → 6rem on mobile, 7rem from `md`.
