### PR TITLE
feat(color-slider): draw the hue track at the current saturation and brightness

### DIFF
--- a/examples/origin-next/src/components/ui/color-slider.tsx
+++ b/examples/origin-next/src/components/ui/color-slider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { createContext, use } from "react";
 import * as ColorSliderPrimitives from "react-aria-components/ColorSlider";
 import { composeRenderProps } from "react-aria-components/composeRenderProps";
+import { useLocale } from "react-aria-components/I18nProvider";
 import * as SliderPrimitives from "react-aria-components/Slider";
 import { Provider } from "react-aria-components/slots";
 import * as TextPrimitives from "react-aria-components/Text";
@@ -37,6 +39,8 @@ interface ColorSliderProps extends React.ComponentProps<
   typeof ColorSliderPrimitives.ColorSlider
 > {}
 
+const ChannelContext = createContext<ColorSliderProps["channel"] | null>(null);
+
 const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
   const { root } = colorSliderVariants();
   const descriptionId = useSlotId();
@@ -47,6 +51,7 @@ const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
           TextPrimitives.TextContext,
           { slot: "description", id: descriptionId },
         ],
+        [ChannelContext, props.channel],
       ]}
     >
       <ColorSliderPrimitives.ColorSlider
@@ -72,21 +77,52 @@ const ColorSliderControl = ({
   ...props
 }: ColorSliderControlProps) => {
   const { track } = colorSliderVariants();
+  const state = use(ColorSliderPrimitives.ColorSliderStateContext);
+  const channel = use(ChannelContext);
+  const { direction } = useLocale();
+  // The hue track previews every hue at the current saturation/brightness
+  // instead of the fully saturated ramp React Aria draws by default.
+  const color =
+    channel === "hue" && state
+      ? state.value.withChannelValue("alpha", 1)
+      : null;
   return (
     <SliderPrimitives.SliderTrack
       data-slot="color-slider-control"
       className={composeRenderProps(className, (cn, { orientation }) =>
         track({ orientation, className: cn }),
       )}
-      style={composeRenderProps(style, (style, { defaultStyle }) => ({
-        ...defaultStyle,
-        ...style,
-        background: `${defaultStyle?.background},
+      style={composeRenderProps(
+        style,
+        (style, { defaultStyle, orientation }) => {
+          let gradient = defaultStyle?.background;
+          if (color) {
+            const to =
+              orientation === "vertical"
+                ? "top"
+                : direction === "rtl"
+                  ? "left"
+                  : "right";
+            const stops = [0, 60, 120, 180, 240, 300, 360]
+              .map((hue) => color.withChannelValue("hue", hue).toString("css"))
+              .join(", ");
+            gradient = `linear-gradient(to ${to}, ${stops})`;
+          }
+          return {
+            ...defaultStyle,
+            ...style,
+            background: `${gradient},
       repeating-conic-gradient(#e6e6e6 0% 25%, #fff 0% 50%) 50% / 16px 16px`,
-      }))}
+          };
+        },
+      )}
       {...props}
     >
-      {props.children ?? <ColorThumb />}
+      {props.children ?? (
+        <ColorThumb
+          style={color ? { backgroundColor: color.toString("css") } : undefined}
+        />
+      )}
     </SliderPrimitives.SliderTrack>
   );
 };

--- a/examples/origin-tanstack-start/src/components/ui/color-slider.tsx
+++ b/examples/origin-tanstack-start/src/components/ui/color-slider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { createContext, use } from "react";
 import * as ColorSliderPrimitives from "react-aria-components/ColorSlider";
 import { composeRenderProps } from "react-aria-components/composeRenderProps";
+import { useLocale } from "react-aria-components/I18nProvider";
 import * as SliderPrimitives from "react-aria-components/Slider";
 import { Provider } from "react-aria-components/slots";
 import * as TextPrimitives from "react-aria-components/Text";
@@ -37,6 +39,8 @@ interface ColorSliderProps extends React.ComponentProps<
   typeof ColorSliderPrimitives.ColorSlider
 > {}
 
+const ChannelContext = createContext<ColorSliderProps["channel"] | null>(null);
+
 const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
   const { root } = colorSliderVariants();
   const descriptionId = useSlotId();
@@ -47,6 +51,7 @@ const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
           TextPrimitives.TextContext,
           { slot: "description", id: descriptionId },
         ],
+        [ChannelContext, props.channel],
       ]}
     >
       <ColorSliderPrimitives.ColorSlider
@@ -72,21 +77,52 @@ const ColorSliderControl = ({
   ...props
 }: ColorSliderControlProps) => {
   const { track } = colorSliderVariants();
+  const state = use(ColorSliderPrimitives.ColorSliderStateContext);
+  const channel = use(ChannelContext);
+  const { direction } = useLocale();
+  // The hue track previews every hue at the current saturation/brightness
+  // instead of the fully saturated ramp React Aria draws by default.
+  const color =
+    channel === "hue" && state
+      ? state.value.withChannelValue("alpha", 1)
+      : null;
   return (
     <SliderPrimitives.SliderTrack
       data-slot="color-slider-control"
       className={composeRenderProps(className, (cn, { orientation }) =>
         track({ orientation, className: cn }),
       )}
-      style={composeRenderProps(style, (style, { defaultStyle }) => ({
-        ...defaultStyle,
-        ...style,
-        background: `${defaultStyle?.background},
+      style={composeRenderProps(
+        style,
+        (style, { defaultStyle, orientation }) => {
+          let gradient = defaultStyle?.background;
+          if (color) {
+            const to =
+              orientation === "vertical"
+                ? "top"
+                : direction === "rtl"
+                  ? "left"
+                  : "right";
+            const stops = [0, 60, 120, 180, 240, 300, 360]
+              .map((hue) => color.withChannelValue("hue", hue).toString("css"))
+              .join(", ");
+            gradient = `linear-gradient(to ${to}, ${stops})`;
+          }
+          return {
+            ...defaultStyle,
+            ...style,
+            background: `${gradient},
       repeating-conic-gradient(#e6e6e6 0% 25%, #fff 0% 50%) 50% / 16px 16px`,
-      }))}
+          };
+        },
+      )}
       {...props}
     >
-      {props.children ?? <ColorThumb />}
+      {props.children ?? (
+        <ColorThumb
+          style={color ? { backgroundColor: color.toString("css") } : undefined}
+        />
+      )}
     </SliderPrimitives.SliderTrack>
   );
 };

--- a/examples/spotify-next/src/components/ui/color-slider.tsx
+++ b/examples/spotify-next/src/components/ui/color-slider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { createContext, use } from "react";
 import * as ColorSliderPrimitives from "react-aria-components/ColorSlider";
 import { composeRenderProps } from "react-aria-components/composeRenderProps";
+import { useLocale } from "react-aria-components/I18nProvider";
 import * as SliderPrimitives from "react-aria-components/Slider";
 import { Provider } from "react-aria-components/slots";
 import * as TextPrimitives from "react-aria-components/Text";
@@ -37,6 +39,8 @@ interface ColorSliderProps extends React.ComponentProps<
   typeof ColorSliderPrimitives.ColorSlider
 > {}
 
+const ChannelContext = createContext<ColorSliderProps["channel"] | null>(null);
+
 const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
   const { root } = colorSliderVariants();
   const descriptionId = useSlotId();
@@ -47,6 +51,7 @@ const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
           TextPrimitives.TextContext,
           { slot: "description", id: descriptionId },
         ],
+        [ChannelContext, props.channel],
       ]}
     >
       <ColorSliderPrimitives.ColorSlider
@@ -72,21 +77,52 @@ const ColorSliderControl = ({
   ...props
 }: ColorSliderControlProps) => {
   const { track } = colorSliderVariants();
+  const state = use(ColorSliderPrimitives.ColorSliderStateContext);
+  const channel = use(ChannelContext);
+  const { direction } = useLocale();
+  // The hue track previews every hue at the current saturation/brightness
+  // instead of the fully saturated ramp React Aria draws by default.
+  const color =
+    channel === "hue" && state
+      ? state.value.withChannelValue("alpha", 1)
+      : null;
   return (
     <SliderPrimitives.SliderTrack
       data-slot="color-slider-control"
       className={composeRenderProps(className, (cn, { orientation }) =>
         track({ orientation, className: cn }),
       )}
-      style={composeRenderProps(style, (style, { defaultStyle }) => ({
-        ...defaultStyle,
-        ...style,
-        background: `${defaultStyle?.background},
+      style={composeRenderProps(
+        style,
+        (style, { defaultStyle, orientation }) => {
+          let gradient = defaultStyle?.background;
+          if (color) {
+            const to =
+              orientation === "vertical"
+                ? "top"
+                : direction === "rtl"
+                  ? "left"
+                  : "right";
+            const stops = [0, 60, 120, 180, 240, 300, 360]
+              .map((hue) => color.withChannelValue("hue", hue).toString("css"))
+              .join(", ");
+            gradient = `linear-gradient(to ${to}, ${stops})`;
+          }
+          return {
+            ...defaultStyle,
+            ...style,
+            background: `${gradient},
       repeating-conic-gradient(#e6e6e6 0% 25%, #fff 0% 50%) 50% / 16px 16px`,
-      }))}
+          };
+        },
+      )}
       {...props}
     >
-      {props.children ?? <ColorThumb />}
+      {props.children ?? (
+        <ColorThumb
+          style={color ? { backgroundColor: color.toString("css") } : undefined}
+        />
+      )}
     </SliderPrimitives.SliderTrack>
   );
 };

--- a/examples/spotify-tanstack-start/src/components/ui/color-slider.tsx
+++ b/examples/spotify-tanstack-start/src/components/ui/color-slider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { createContext, use } from "react";
 import * as ColorSliderPrimitives from "react-aria-components/ColorSlider";
 import { composeRenderProps } from "react-aria-components/composeRenderProps";
+import { useLocale } from "react-aria-components/I18nProvider";
 import * as SliderPrimitives from "react-aria-components/Slider";
 import { Provider } from "react-aria-components/slots";
 import * as TextPrimitives from "react-aria-components/Text";
@@ -37,6 +39,8 @@ interface ColorSliderProps extends React.ComponentProps<
   typeof ColorSliderPrimitives.ColorSlider
 > {}
 
+const ChannelContext = createContext<ColorSliderProps["channel"] | null>(null);
+
 const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
   const { root } = colorSliderVariants();
   const descriptionId = useSlotId();
@@ -47,6 +51,7 @@ const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
           TextPrimitives.TextContext,
           { slot: "description", id: descriptionId },
         ],
+        [ChannelContext, props.channel],
       ]}
     >
       <ColorSliderPrimitives.ColorSlider
@@ -72,21 +77,52 @@ const ColorSliderControl = ({
   ...props
 }: ColorSliderControlProps) => {
   const { track } = colorSliderVariants();
+  const state = use(ColorSliderPrimitives.ColorSliderStateContext);
+  const channel = use(ChannelContext);
+  const { direction } = useLocale();
+  // The hue track previews every hue at the current saturation/brightness
+  // instead of the fully saturated ramp React Aria draws by default.
+  const color =
+    channel === "hue" && state
+      ? state.value.withChannelValue("alpha", 1)
+      : null;
   return (
     <SliderPrimitives.SliderTrack
       data-slot="color-slider-control"
       className={composeRenderProps(className, (cn, { orientation }) =>
         track({ orientation, className: cn }),
       )}
-      style={composeRenderProps(style, (style, { defaultStyle }) => ({
-        ...defaultStyle,
-        ...style,
-        background: `${defaultStyle?.background},
+      style={composeRenderProps(
+        style,
+        (style, { defaultStyle, orientation }) => {
+          let gradient = defaultStyle?.background;
+          if (color) {
+            const to =
+              orientation === "vertical"
+                ? "top"
+                : direction === "rtl"
+                  ? "left"
+                  : "right";
+            const stops = [0, 60, 120, 180, 240, 300, 360]
+              .map((hue) => color.withChannelValue("hue", hue).toString("css"))
+              .join(", ");
+            gradient = `linear-gradient(to ${to}, ${stops})`;
+          }
+          return {
+            ...defaultStyle,
+            ...style,
+            background: `${gradient},
       repeating-conic-gradient(#e6e6e6 0% 25%, #fff 0% 50%) 50% / 16px 16px`,
-      }))}
+          };
+        },
+      )}
       {...props}
     >
-      {props.children ?? <ColorThumb />}
+      {props.children ?? (
+        <ColorThumb
+          style={color ? { backgroundColor: color.toString("css") } : undefined}
+        />
+      )}
     </SliderPrimitives.SliderTrack>
   );
 };

--- a/www/src/registry/ui/color-slider/base.tsx
+++ b/www/src/registry/ui/color-slider/base.tsx
@@ -1,7 +1,9 @@
 "use client"
 
+import { createContext, use } from "react"
 import * as ColorSliderPrimitives from "react-aria-components/ColorSlider"
 import { composeRenderProps } from "react-aria-components/composeRenderProps"
+import { useLocale } from "react-aria-components/I18nProvider"
 import * as SliderPrimitives from "react-aria-components/Slider"
 import { Provider } from "react-aria-components/slots"
 import * as TextPrimitives from "react-aria-components/Text"
@@ -19,6 +21,8 @@ interface ColorSliderProps extends React.ComponentProps<
   typeof ColorSliderPrimitives.ColorSlider
 > {}
 
+const ChannelContext = createContext<ColorSliderProps["channel"] | null>(null)
+
 const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
   const { root } = useStyles()()
   const descriptionId = useSlotId()
@@ -29,6 +33,7 @@ const ColorSlider = ({ className, ...props }: ColorSliderProps) => {
           TextPrimitives.TextContext,
           { slot: "description", id: descriptionId },
         ],
+        [ChannelContext, props.channel],
       ]}
     >
       <ColorSliderPrimitives.ColorSlider
@@ -56,21 +61,50 @@ const ColorSliderControl = ({
   ...props
 }: ColorSliderControlProps) => {
   const { track } = useStyles()()
+  const state = use(ColorSliderPrimitives.ColorSliderStateContext)
+  const channel = use(ChannelContext)
+  const { direction } = useLocale()
+  // The hue track previews every hue at the current saturation/brightness
+  // instead of the fully saturated ramp React Aria draws by default.
+  const color =
+    channel === "hue" && state ? state.value.withChannelValue("alpha", 1) : null
   return (
     <SliderPrimitives.SliderTrack
       data-slot="color-slider-control"
       className={composeRenderProps(className, (cn, { orientation }) =>
         track({ orientation, className: cn }),
       )}
-      style={composeRenderProps(style, (style, { defaultStyle }) => ({
-        ...defaultStyle,
-        ...style,
-        background: `${defaultStyle?.background},
+      style={composeRenderProps(
+        style,
+        (style, { defaultStyle, orientation }) => {
+          let gradient = defaultStyle?.background
+          if (color) {
+            const to =
+              orientation === "vertical"
+                ? "top"
+                : direction === "rtl"
+                  ? "left"
+                  : "right"
+            const stops = [0, 60, 120, 180, 240, 300, 360]
+              .map((hue) => color.withChannelValue("hue", hue).toString("css"))
+              .join(", ")
+            gradient = `linear-gradient(to ${to}, ${stops})`
+          }
+          return {
+            ...defaultStyle,
+            ...style,
+            background: `${gradient},
       repeating-conic-gradient(#e6e6e6 0% 25%, #fff 0% 50%) 50% / 16px 16px`,
-      }))}
+          }
+        },
+      )}
       {...props}
     >
-      {props.children ?? <ColorThumb />}
+      {props.children ?? (
+        <ColorThumb
+          style={color ? { backgroundColor: color.toString("css") } : undefined}
+        />
+      )}
     </SliderPrimitives.SliderTrack>
   )
 }


### PR DESCRIPTION
## Summary

- The hue slider's track now previews every hue at the color's current saturation and brightness, instead of React Aria's fixed fully-saturated ramp (`hsl(h, 100%, 50%)`). Pick a pale pink and the track turns pastel; pick a dark teal and it darkens. The hue thumb shows the real color too, not the pure hue.
- The alpha track already ran transparent → current color in React Aria, so it needed no change.
- `ColorSlider` hands its `channel` to `ColorSliderControl` through a small context (the RAC slider state doesn't expose it). Only `channel="hue"` overrides the gradient; other channels keep RAC's default. Orientation and RTL are honored.
- Applies wherever the slider is used: the docs color editor, the studio color pickers, and color-lab. `examples/*` regenerated via `pnpm smoke:examples`.

Inspired by DialKit's picker: https://x.com/joshpuckett/status/2096652526628323364

Tradeoff: at zero saturation or brightness the hue track is a flat gray/black bar, which is the honest result of this behavior.