### PR TITLE
docs: add Nuxt UI theme editor to references

### DIFF
--- a/docs/design-system-references.md
+++ b/docs/design-system-references.md
@@ -42,6 +42,7 @@ The systems worth studying when researching presets, missing axes, or component 
 - [shadcn/create](https://ui.shadcn.com/create)
 - [HeroUI Pro Theme Editor](https://heroui.pro/ds)
 - [Astryx Playground](https://astryx.atmeta.com/playground)
+- [Nuxt UI Theme Editor](https://ui.nuxt.com/theme)
 
 ### Preset targets
 


### PR DESCRIPTION
Adds [Nuxt UI Theme Editor](https://ui.nuxt.com/theme) under **Inspiration → Preset customizer** in `docs/design-system-references.md`, alongside shadcn/create, HeroUI Pro and the Astryx Playground.

It's another builder-style theme editor worth studying when working on /studio panel axes and preset fidelity.