### PR TITLE
perf(docs): highlight runtime code with sugar-high

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       starter-themes:
         specifier: ^0.0.2
         version: 0.0.2(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-start@1.168.2(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.1)
+      sugar-high:
+        specifier: ^2.3.1
+        version: 2.3.1
       tailwind-variants:
         specifier: ^3.3.0
         version: 3.3.0(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
@@ -489,11 +492,6 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5862,6 +5860,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sugar-high@2.3.1:
+    resolution: {integrity: sha512-LwFbTGo9j3qYLnId35kkKufYdSil0jsmiac27MM6jTT5V62rmVM4r65XpSaiB9CSKqZUNCIrL64HZkGhVEDu9g==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6621,8 +6622,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -6672,7 +6673,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -6718,13 +6719,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.7
-
   '@babel/parser@7.29.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -10469,7 +10466,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -12017,6 +12014,8 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
     optional: true
+
+  sugar-high@2.3.1: {}
 
   supports-color@7.2.0:
     dependencies:

--- a/www/package.json
+++ b/www/package.json
@@ -61,6 +61,7 @@
     "shiki": "^4.0.2",
     "shiki-magic-move": "^1.4.0",
     "starter-themes": "^0.0.2",
+    "sugar-high": "^2.3.1",
     "tailwind-variants": "^3.3.0",
     "tailwindcss": "catalog:",
     "tailwindcss-react-aria-components": "^2.2.0",

--- a/www/src/modules/charts/chart-code-modal-content.tsx
+++ b/www/src/modules/charts/chart-code-modal-content.tsx
@@ -30,9 +30,8 @@ interface ChartCodeModalContentProps {
 /**
  * Body of the "Show code" modal — title, live preview, and install command on
  * the left; the variant's source filling the full modal height on the right.
- * Lazily mounted (see chart-code-modal), so its heavy imports (the highlighter)
- * load only on first open. Source is read via `use()` against a cached promise,
- * so the modal suspends until it resolves.
+ * Lazily mounted (see chart-code-modal). Source is read via `use()` against a
+ * cached promise, so the modal suspends until it resolves.
  */
 export default function ChartCodeModalContent({
   demoKey,

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -12,11 +12,7 @@ import {
 } from "diff-match-patch-es"
 import { PauseIcon, PlayIcon } from "lucide-react"
 import { Pressable } from "react-aria-components/Pressable"
-import {
-  codeToKeyedTokens,
-  syncTokenKeys,
-  toKeyedTokens,
-} from "shiki-magic-move/core"
+import { syncTokenKeys, toKeyedTokens } from "shiki-magic-move/core"
 import { ShikiMagicMoveRenderer } from "shiki-magic-move/react"
 import type { KeyedToken, KeyedTokensInfo } from "shiki-magic-move/types"
 import { useTheme } from "starter-themes"
@@ -61,7 +57,7 @@ import { SearchField } from "@/registry/ui/search-field"
 import { Select, SelectValue } from "@/registry/ui/select"
 import { Tag, TagGroup, TagList } from "@/registry/ui/tag-group"
 import { TextField } from "@/registry/ui/text-field"
-import { highlighter } from "@/modules/docs/highlight"
+import { tokenizeTsx } from "@/modules/docs/highlight"
 
 interface Step {
   title: string
@@ -1305,6 +1301,17 @@ function lockTagPunctuation(from: KeyedTokensInfo, to: KeyedTokensInfo) {
 
 const EMPTY_TOKENS = toKeyedTokens("", [])
 
+function keyedTokens(code: string, theme: "light" | "dark"): KeyedTokensInfo {
+  const lines = tokenizeTsx(code).map((line) =>
+    line.map(({ content, offset, light, dark }) => ({
+      content,
+      offset,
+      color: theme === "light" ? light : dark,
+    })),
+  )
+  return { ...toKeyedTokens(code, lines), themeName: theme }
+}
+
 // The gutter is sized for the loop's longest snippet, so it can't widen at line
 // 10 and shift the code sideways mid-transition.
 export const lineNumberWidth = String(maxCodeLines).length
@@ -1351,7 +1358,7 @@ export function CompositionCode({
   lineNumbers?: boolean
 }) {
   const { resolvedTheme } = useTheme()
-  const theme = resolvedTheme === "light" ? "github-light" : "github-dark"
+  const theme = resolvedTheme === "light" ? "light" : "dark"
   // Inlined ShikiMagicMove machine so lockTagPunctuation can rewrite the
   // synced keys before they reach the renderer. The code/theme guard keeps a
   // strict-mode double render from committing the same step twice (which
@@ -1364,7 +1371,7 @@ export function CompositionCode({
     if (previous.code === code && previous.themeName === theme) {
       return cache.current!
     }
-    const next = codeToKeyedTokens(highlighter, code, { lang: "tsx", theme })
+    const next = keyedTokens(code, theme)
     const { from, to } = syncTokenKeys(previous, next, {
       diffCleanup: cleanupCodeDiff,
     })

--- a/www/src/modules/docs/highlight.test.ts
+++ b/www/src/modules/docs/highlight.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs"
+import path from "node:path"
+import { createHighlighterCoreSync } from "shiki/core"
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript"
+import tsx from "shiki/langs/tsx.mjs"
+import githubDark from "shiki/themes/github-dark.mjs"
+import githubLight from "shiki/themes/github-light.mjs"
+import { describe, expect, it } from "vitest"
+
+import { tokenizeTsx } from "./highlight"
+
+// The runtime highlighter must paint the playground sources like the build-time
+// shiki output next to them on a docs page. Compares every non-whitespace
+// character's color across all playground demos and caps the mismatch rate.
+
+const MAX_MISMATCH = 0.01
+
+const shiki = createHighlighterCoreSync({
+  langs: [tsx],
+  themes: [githubLight, githubDark],
+  engine: createJavaScriptRegexEngine({ forgiving: true }),
+})
+
+const FG = { light: "#24292e", dark: "#e1e4e8" }
+
+const uiDir = path.join(import.meta.dirname, "../../registry/ui")
+const playgrounds = fs
+  .readdirSync(uiDir)
+  .map((name) => path.join(uiDir, name, "demos/playground.tsx"))
+  .filter((file) => fs.existsSync(file))
+
+function shikiColors(code: string, mode: "light" | "dark") {
+  const colors: (string | null)[] = []
+  const { tokens } = shiki.codeToTokens(code, {
+    lang: "tsx",
+    themes: { light: "github-light", dark: "github-dark" },
+    defaultColor: false,
+  })
+  for (const line of tokens) {
+    for (const token of line) {
+      const style = token.htmlStyle as Record<string, string> | undefined
+      const color = (style?.[`--shiki-${mode}`] ?? FG[mode]).toLowerCase()
+      for (const _ of token.content) colors.push(color)
+    }
+    colors.push(null)
+  }
+  return colors
+}
+
+describe.each(["light", "dark"] as const)(
+  "tokenizeTsx vs shiki (%s)",
+  (mode) => {
+    it("colors playground sources like shiki", () => {
+      let total = 0
+      let mismatched = 0
+      const byToken = new Map<string, number>()
+      for (const file of playgrounds) {
+        const code = fs.readFileSync(file, "utf8")
+        const expected = shikiColors(code, mode)
+        let i = 0
+        for (const line of tokenizeTsx(code)) {
+          for (const token of line) {
+            const color = token[mode].toLowerCase()
+            let misses = 0
+            for (const ch of token.content) {
+              const want = expected[i++]
+              if (/\s/.test(ch)) continue
+              total++
+              if (want !== color) misses++
+            }
+            if (misses) {
+              mismatched += misses
+              const key = `${JSON.stringify(token.content)} ${color} (shiki ${expected[i - 1]})`
+              byToken.set(key, (byToken.get(key) ?? 0) + misses)
+            }
+          }
+          i++
+        }
+      }
+      const rate = mismatched / total
+      const worst = [...byToken]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 10)
+        .map(([key, n]) => `  ${String(n).padStart(4)} ${key}`)
+        .join("\n")
+      expect(
+        rate,
+        `mismatch ${(100 * rate).toFixed(2)}%\n${worst}`,
+      ).toBeLessThanOrEqual(MAX_MISMATCH)
+    })
+  },
+)

--- a/www/src/modules/docs/highlight.ts
+++ b/www/src/modules/docs/highlight.ts
@@ -59,6 +59,7 @@ const TYPE_PREFIX = new Set([
   "satisfies",
 ])
 const OPERATOR = /^[=&|?!+\-*/%]+$/
+const OPENERS = new Set(["(", "{", ",", ";"])
 
 interface State {
   /** Paren depth inside a `function` parameter list; 0 when outside one. */
@@ -79,6 +80,13 @@ function significant(
     if (token && token.type !== "space") return token
   }
   return undefined
+}
+
+/** `const a = …` / `const { a, b } = …` — a binding name shiki paints as a constant. */
+function isConstName(tokens: readonly ParsedToken[], index: number): boolean {
+  if (tokens.find((t) => t.type !== "space")?.value !== "const") return false
+  for (let i = 0; i < index; i++) if (tokens[i]?.value === "=") return false
+  return true
 }
 
 /** `(a, b) =>` — the identifier at `index` sits in an arrow function's parameter list. */
@@ -119,8 +127,8 @@ function colorsOf(
       if (next?.value === ":") return FG
       return KEYWORD
     case "identifier": {
-      const opensName =
-        !prev || prev.value === "(" || prev.value === "{" || prev.value === ","
+      if (isConstName(tokens, index)) return CONSTANT
+      const opensName = !prev || OPENERS.has(prev.value)
       if (
         opensName &&
         (state.params > 0 || state.members > 0 || isArrowParam(tokens, index))
@@ -134,6 +142,7 @@ function colorsOf(
       if (
         prev?.value === "function" ||
         prev?.value === "interface" ||
+        prev?.value === "new" ||
         (prev && TYPE_PREFIX.has(prev.value))
       )
         return ENTITY

--- a/www/src/modules/docs/highlight.ts
+++ b/www/src/modules/docs/highlight.ts
@@ -1,34 +1,247 @@
 import type { Root } from "hast"
-import { createHighlighterCoreSync } from "shiki/core"
-import { createJavaScriptRegexEngine } from "shiki/engine/javascript"
-import tsx from "shiki/langs/tsx.mjs"
-import githubDark from "shiki/themes/github-dark.mjs"
-import githubLight from "shiki/themes/github-light.mjs"
+import { parse, type ParsedToken, type TokenType } from "sugar-high/core"
+import * as typescript from "sugar-high/lang/typescript"
 
 /**
  * Synchronous TSX highlighter for code the client generates at runtime
- * (playground output). Static docs code is highlighted at build time by the
- * rehype pipeline — this module exists for code that doesn't exist until the
- * user moves a control.
- *
- * Everything is statically imported (grammar + themes ≈ 35KB gzipped) so
- * highlighting works during SSR and on the very first render — no async
- * highlighter load, no flash of unhighlighted code, ever.
+ * (playground output, exported source). Static docs code is highlighted at
+ * build time by shiki in the rehype pipeline; this runs sugar-high (~4 KB)
+ * instead of shipping shiki's grammar and engine to the browser, and paints
+ * its tokens with the same github-light / github-dark colors so both look alike.
  */
-const highlighter = createHighlighterCoreSync({
-  langs: [tsx],
-  themes: [githubLight, githubDark],
-  engine: createJavaScriptRegexEngine({ forgiving: true }),
-})
 
-/** The raw highlighter, for consumers that need token-level access (magic-move). */
-export { highlighter }
+type Colors = [light: string, dark: string]
 
-/** Highlight TSX to HAST with the same dual-theme CSS variables the build uses. */
-export function highlightTsx(code: string): Root {
-  return highlighter.codeToHast(code, {
-    lang: "tsx",
-    themes: { light: "github-light", dark: "github-dark" },
-    defaultColor: false,
+const FG: Colors = ["#24292E", "#E1E4E8"]
+const KEYWORD: Colors = ["#D73A49", "#F97583"]
+const STRING: Colors = ["#032F62", "#9ECBFF"]
+const COMMENT: Colors = ["#6A737D", "#6A737D"]
+const ENTITY: Colors = ["#6F42C1", "#B392F0"]
+const CONSTANT: Colors = ["#005CC5", "#79B8FF"]
+const TAG: Colors = ["#22863A", "#85E89D"]
+const PARAM: Colors = ["#E36209", "#FFAB70"]
+
+const COLORS: Record<TokenType, Colors> = {
+  identifier: FG,
+  sign: FG,
+  space: FG,
+  break: FG,
+  jsxliterals: FG,
+  keyword: KEYWORD,
+  string: STRING,
+  comment: COMMENT,
+  class: FG,
+  entity: ENTITY,
+  property: FG,
+}
+
+const LITERALS = new Set(["true", "false", "null", "undefined"])
+const PRIMITIVES = new Set([
+  "string",
+  "number",
+  "boolean",
+  "object",
+  "symbol",
+  "bigint",
+  "any",
+  "unknown",
+  "never",
+  "void",
+])
+const TYPE_PREFIX = new Set([
+  ":",
+  "<",
+  "|",
+  "&",
+  "as",
+  "extends",
+  "keyof",
+  "satisfies",
+])
+const OPERATOR = /^[=&|?!+\-*/%]+$/
+
+interface State {
+  /** Paren depth inside a `function` parameter list; 0 when outside one. */
+  params: number
+  /** Brace depth inside an `interface` body; 0 when outside one. */
+  members: number
+  /** Seen `function` / `interface`, waiting for its `(` / `{`. */
+  awaiting: "(" | "{" | null
+}
+
+function significant(
+  tokens: readonly ParsedToken[],
+  from: number,
+  step: 1 | -1,
+) {
+  for (let i = from + step; i >= 0 && i < tokens.length; i += step) {
+    const token = tokens[i]
+    if (token && token.type !== "space") return token
+  }
+  return undefined
+}
+
+/** `(a, b) =>` — the identifier at `index` sits in an arrow function's parameter list. */
+function isArrowParam(tokens: readonly ParsedToken[], index: number): boolean {
+  let depth = 0
+  for (let i = index + 1; i < tokens.length; i++) {
+    const value = tokens[i]?.value
+    if (value === "(" || value === "{" || value === "[") depth++
+    else if (value === ")" || value === "}" || value === "]") {
+      if (depth > 0) depth--
+      else
+        return (
+          value === ")" &&
+          tokens[i + 1]?.value === " " &&
+          tokens[i + 2]?.value === "=" &&
+          tokens[i + 3]?.value === ">"
+        )
+    }
+  }
+  return false
+}
+
+// sugar-high's token types are coarser than a TextMate grammar; the lookarounds
+// recover the distinctions github's theme paints (types, tags, params, operators).
+function colorsOf(
+  tokens: readonly ParsedToken[],
+  index: number,
+  state: State,
+): Colors {
+  const token = tokens[index]
+  if (!token) return FG
+  const { type, value } = token
+  const prev = significant(tokens, index, -1)
+  const next = significant(tokens, index, 1)
+  switch (type) {
+    case "keyword":
+      if (LITERALS.has(value) || PRIMITIVES.has(value)) return CONSTANT
+      if (next?.value === ":") return FG
+      return KEYWORD
+    case "identifier": {
+      const opensName =
+        !prev || prev.value === "(" || prev.value === "{" || prev.value === ","
+      if (
+        opensName &&
+        (state.params > 0 || state.members > 0 || isArrowParam(tokens, index))
+      )
+        return PARAM
+      return FG
+    }
+    case "class":
+      if (/^\d/.test(value)) return CONSTANT
+      if (prev?.value === "type") return next?.value === "=" ? ENTITY : FG
+      if (
+        prev?.value === "function" ||
+        prev?.value === "interface" ||
+        (prev && TYPE_PREFIX.has(prev.value))
+      )
+        return ENTITY
+      return FG
+    case "entity":
+      if (prev?.value === "<" || prev?.value === "</") {
+        return /^[A-Z]/.test(value) ? CONSTANT : TAG
+      }
+      return ENTITY
+    case "property":
+      if (next?.value === ":") return FG
+      if (prev?.value === "." && next?.value !== "(") return FG
+      return ENTITY
+    case "sign":
+      if (OPERATOR.test(value)) return KEYWORD
+      if (value === ">" && prev?.value === "=") return KEYWORD
+      if (value === ":" && next) {
+        if (next.type === "class" || PRIMITIVES.has(next.value)) return KEYWORD
+        if (next.value === "{" && state.params > 0) return KEYWORD
+      }
+      return FG
+    default:
+      return COLORS[type]
+  }
+}
+
+function advance(token: ParsedToken, state: State) {
+  const { type, value } = token
+  if (type === "space") return
+  if (value === "function") state.awaiting = "("
+  else if (value === "interface") state.awaiting = "{"
+  else if (value === "(") {
+    if (state.awaiting === "(") state.params = 1
+    else if (state.params > 0) state.params++
+    state.awaiting = null
+  } else if (value === ")") {
+    if (state.params > 0) state.params--
+  } else if (value === "{") {
+    if (state.awaiting === "{") state.members = 1
+    else if (state.members > 0) state.members++
+    state.awaiting = null
+  } else if (value === "}") {
+    if (state.members > 0) state.members--
+  } else if (type !== "class" && type !== "identifier") {
+    state.awaiting = null
+  }
+}
+
+export interface Token {
+  content: string
+  /** Start offset in the source, 0-indexed. */
+  offset: number
+  light: string
+  dark: string
+}
+
+/** Tokenize TSX into lines of colored tokens (no newline tokens). */
+export function tokenizeTsx(code: string): Token[][] {
+  const state: State = { params: 0, members: 0, awaiting: null }
+  let offset = 0
+  return parse(code, typescript).lines.map((line) => {
+    const tokens: Token[] = []
+    let cursor = offset
+    line.tokens.forEach((token, index) => {
+      if (!token.value) return
+      const [light, dark] = colorsOf(line.tokens, index, state)
+      advance(token, state)
+      tokens.push({ content: token.value, offset: cursor, light, dark })
+      cursor += token.value.length
+    })
+    offset += line.value.length + 1
+    return tokens
   })
+}
+
+/**
+ * Highlight TSX to HAST in the shape shiki emits (`pre > code > span.line`,
+ * `--shiki-light` / `--shiki-dark` on every token), so the same <Pre> styles
+ * render both.
+ */
+export function highlightTsx(code: string): Root {
+  const lines = tokenizeTsx(code).flatMap((tokens, index) => {
+    const line = {
+      type: "element" as const,
+      tagName: "span",
+      properties: { className: ["line"] },
+      children: tokens.map((token) => ({
+        type: "element" as const,
+        tagName: "span",
+        properties: {
+          style: `--shiki-light:${token.light};--shiki-dark:${token.dark}`,
+        },
+        children: [{ type: "text" as const, value: token.content }],
+      })),
+    }
+    return index === 0 ? [line] : [{ type: "text" as const, value: "\n" }, line]
+  })
+  return {
+    type: "root",
+    children: [
+      {
+        type: "element",
+        tagName: "pre",
+        properties: { tabIndex: 0 },
+        children: [
+          { type: "element", tagName: "code", properties: {}, children: lines },
+        ],
+      },
+    ],
+  }
 }

--- a/www/src/modules/studio/code-options/preview.tsx
+++ b/www/src/modules/studio/code-options/preview.tsx
@@ -2,8 +2,7 @@
  * Live preview of the exported button component. Fetches the real `/r/button`
  * registry endpoint (same publisher + oxfmt the user gets on install),
  * debounced and same-origin, so every codeOptions toggle shows the actual
- * resulting source. Highlighting reuses the docs `DynamicPre` (synchronous
- * shiki).
+ * resulting source. Highlighting reuses the docs `DynamicPre`.
  */
 
 import { useEffect, useState } from "react"

--- a/www/src/routeTree.gen.ts
+++ b/www/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as RNameRouteImport } from './routes/r/$name'
 import { Route as PreviewSlugRouteImport } from './routes/preview/$slug'
 import { Route as InternalRegistriesRouteImport } from './routes/internal.registries'
 import { Route as InternalPresetLabRouteImport } from './routes/internal.preset-lab'
+import { Route as InternalHighlightCompareRouteImport } from './routes/internal.highlight-compare'
 import { Route as InternalColorLabRouteImport } from './routes/internal.color-lab'
 import { Route as InternalBlurRevealRouteImport } from './routes/internal.blur-reveal'
 import { Route as DemosSlugRouteImport } from './routes/demos/$slug'
@@ -118,6 +119,12 @@ const InternalPresetLabRoute = InternalPresetLabRouteImport.update({
   path: '/internal/preset-lab',
   getParentRoute: () => rootRouteImport,
 } as any)
+const InternalHighlightCompareRoute =
+  InternalHighlightCompareRouteImport.update({
+    id: '/internal/highlight-compare',
+    path: '/internal/highlight-compare',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InternalColorLabRoute = InternalColorLabRouteImport.update({
   id: '/internal/color-lab',
   path: '/internal/color-lab',
@@ -204,6 +211,7 @@ export interface FileRoutesByFullPath {
   '/demos/$slug': typeof DemosSlugRoute
   '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
+  '/internal/highlight-compare': typeof InternalHighlightCompareRoute
   '/internal/preset-lab': typeof InternalPresetLabRoute
   '/internal/registries': typeof InternalRegistriesRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -233,6 +241,7 @@ export interface FileRoutesByTo {
   '/demos/$slug': typeof DemosSlugRoute
   '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
+  '/internal/highlight-compare': typeof InternalHighlightCompareRoute
   '/internal/preset-lab': typeof InternalPresetLabRoute
   '/internal/registries': typeof InternalRegistriesRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -265,6 +274,7 @@ export interface FileRoutesById {
   '/demos/$slug': typeof DemosSlugRoute
   '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
+  '/internal/highlight-compare': typeof InternalHighlightCompareRoute
   '/internal/preset-lab': typeof InternalPresetLabRoute
   '/internal/registries': typeof InternalRegistriesRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -298,6 +308,7 @@ export interface FileRouteTypes {
     | '/demos/$slug'
     | '/internal/blur-reveal'
     | '/internal/color-lab'
+    | '/internal/highlight-compare'
     | '/internal/preset-lab'
     | '/internal/registries'
     | '/preview/$slug'
@@ -327,6 +338,7 @@ export interface FileRouteTypes {
     | '/demos/$slug'
     | '/internal/blur-reveal'
     | '/internal/color-lab'
+    | '/internal/highlight-compare'
     | '/internal/preset-lab'
     | '/internal/registries'
     | '/preview/$slug'
@@ -358,6 +370,7 @@ export interface FileRouteTypes {
     | '/demos/$slug'
     | '/internal/blur-reveal'
     | '/internal/color-lab'
+    | '/internal/highlight-compare'
     | '/internal/preset-lab'
     | '/internal/registries'
     | '/preview/$slug'
@@ -384,6 +397,7 @@ export interface RootRouteChildren {
   DemosSlugRoute: typeof DemosSlugRoute
   InternalBlurRevealRoute: typeof InternalBlurRevealRoute
   InternalColorLabRoute: typeof InternalColorLabRoute
+  InternalHighlightCompareRoute: typeof InternalHighlightCompareRoute
   InternalPresetLabRoute: typeof InternalPresetLabRoute
   InternalRegistriesRoute: typeof InternalRegistriesRoute
   PreviewSlugRoute: typeof PreviewSlugRoute
@@ -506,6 +520,13 @@ declare module '@tanstack/react-router' {
       path: '/internal/preset-lab'
       fullPath: '/internal/preset-lab'
       preLoaderRoute: typeof InternalPresetLabRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/internal/highlight-compare': {
+      id: '/internal/highlight-compare'
+      path: '/internal/highlight-compare'
+      fullPath: '/internal/highlight-compare'
+      preLoaderRoute: typeof InternalHighlightCompareRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/internal/color-lab': {
@@ -653,6 +674,7 @@ const rootRouteChildren: RootRouteChildren = {
   DemosSlugRoute: DemosSlugRoute,
   InternalBlurRevealRoute: InternalBlurRevealRoute,
   InternalColorLabRoute: InternalColorLabRoute,
+  InternalHighlightCompareRoute: InternalHighlightCompareRoute,
   InternalPresetLabRoute: InternalPresetLabRoute,
   InternalRegistriesRoute: InternalRegistriesRoute,
   PreviewSlugRoute: PreviewSlugRoute,

--- a/www/src/routes/internal.highlight-compare.tsx
+++ b/www/src/routes/internal.highlight-compare.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useMemo, useState } from "react"
+import { Fragment, jsx, jsxs } from "react/jsx-runtime"
+import { createFileRoute } from "@tanstack/react-router"
+import type { Element, ElementContent, Root, RootContent } from "hast"
+import { toJsxRuntime } from "hast-util-to-jsx-runtime"
+import { createHighlighterCoreSync } from "shiki/core"
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript"
+import tsx from "shiki/langs/tsx.mjs"
+import githubDark from "shiki/themes/github-dark.mjs"
+import githubLight from "shiki/themes/github-light.mjs"
+
+import { cn } from "@/registry/lib/utils"
+import { Button } from "@/registry/ui/button"
+import { Pre } from "@/modules/docs/code-block"
+import { highlightTsx } from "@/modules/docs/highlight"
+import { InternalHeader } from "@/modules/internal/shell"
+
+export const Route = createFileRoute("/internal/highlight-compare")({
+  component: HighlightCompare,
+  head: () => ({ meta: [{ title: "Highlight compare · Internal · dotUI" }] }),
+})
+
+// Every playground source the docs highlight at runtime, old (shiki) vs new
+// (sugar-high), with each character whose color differs marked in the new
+// column. Temporary — review aid for the sugar-high migration.
+
+const shiki = createHighlighterCoreSync({
+  langs: [tsx],
+  themes: [githubLight, githubDark],
+  engine: createJavaScriptRegexEngine({ forgiving: true }),
+})
+
+function highlightShiki(code: string): Root {
+  return shiki.codeToHast(code, {
+    lang: "tsx",
+    themes: { light: "github-light", dark: "github-dark" },
+    defaultColor: false,
+  })
+}
+
+const sources = import.meta.glob("/src/registry/ui/*/demos/playground.tsx", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>
+
+type Mode = "light" | "dark"
+type Char = { ch: string; light: string | null; dark: string | null }
+
+function parseColors(style: unknown): [string | null, string | null] {
+  const s = typeof style === "string" ? style : ""
+  const light = /--shiki-light:\s*([^;]+)/i.exec(s)?.[1]?.trim() ?? null
+  const dark = /--shiki-dark:\s*([^;]+)/i.exec(s)?.[1]?.trim() ?? null
+  return [light?.toLowerCase() ?? null, dark?.toLowerCase() ?? null]
+}
+
+function flatten(root: Root): Char[] {
+  const out: Char[] = []
+  const walk = (
+    node: RootContent,
+    light: string | null,
+    dark: string | null,
+  ) => {
+    if (node.type === "text") {
+      for (const ch of node.value) out.push({ ch, light, dark })
+      return
+    }
+    if (node.type !== "element") return
+    const [l, d] = parseColors(node.properties?.style)
+    for (const child of node.children) walk(child, l ?? light, d ?? dark)
+  }
+  for (const child of root.children) walk(child, null, null)
+  return out
+}
+
+function mismatches(a: Char[], b: Char[], mode: Mode): boolean[] {
+  return b.map((c, i) => {
+    if (/\s/.test(c.ch)) return false
+    const o = a[i]
+    return !o || o.ch !== c.ch || o[mode] !== c[mode]
+  })
+}
+
+// Split token text nodes so mismatched characters get their own marked span.
+function markMismatches(root: Root, flags: boolean[]): Root {
+  let i = 0
+  const walk = (node: Element) => {
+    node.children = node.children.flatMap((child) => {
+      if (child.type === "text") {
+        const parts: ElementContent[] = []
+        let run = ""
+        let runFlag: boolean | null = null
+        const flush = () => {
+          if (!run) return
+          parts.push(
+            runFlag
+              ? {
+                  type: "element",
+                  tagName: "mark",
+                  properties: { className: ["mismatch"] },
+                  children: [{ type: "text", value: run }],
+                }
+              : { type: "text", value: run },
+          )
+          run = ""
+        }
+        for (const ch of child.value) {
+          const flag = flags[i++] ?? false
+          if (runFlag !== null && flag !== runFlag) flush()
+          runFlag = flag
+          run += ch
+        }
+        flush()
+        return parts
+      }
+      if (child.type === "element") walk(child)
+      return [child]
+    })
+  }
+  for (const child of root.children) if (child.type === "element") walk(child)
+  return root
+}
+
+function render(root: Root, className?: string) {
+  return toJsxRuntime(root, {
+    Fragment,
+    jsx,
+    jsxs,
+    components: {
+      pre: (props) => (
+        <Pre {...props} className={cn(props.className, className)} />
+      ),
+    },
+  })
+}
+
+interface Sample {
+  name: string
+  code: string
+  old: Root
+  next: Root
+  chars: number
+  diff: Record<Mode, number>
+  marked: Record<Mode, Root>
+}
+
+function buildSamples(): Sample[] {
+  return Object.entries(sources)
+    .map(([file, code]) => {
+      const name = file.split("/ui/")[1]?.split("/")[0] ?? file
+      const old = highlightShiki(code)
+      const next = highlightTsx(code)
+      const a = flatten(old)
+      const b = flatten(next)
+      const chars = b.filter((c) => !/\s/.test(c.ch)).length
+      const flags = {
+        light: mismatches(a, b, "light"),
+        dark: mismatches(a, b, "dark"),
+      }
+      return {
+        name,
+        code,
+        old,
+        next,
+        chars,
+        diff: {
+          light: flags.light.filter(Boolean).length,
+          dark: flags.dark.filter(Boolean).length,
+        },
+        marked: {
+          light: markMismatches(structuredClone(next), flags.light),
+          dark: markMismatches(structuredClone(next), flags.dark),
+        },
+      }
+    })
+    .sort((x, y) => y.diff.light / y.chars - x.diff.light / x.chars)
+}
+
+function HighlightCompare() {
+  const samples = useMemo(buildSamples, [])
+  const [mode, setMode] = useState<Mode>("light")
+  useEffect(() => {
+    if (window.location.hash === "#dark") setMode("dark")
+  }, [])
+  const [onlyDiff, setOnlyDiff] = useState(false)
+  const total = samples.reduce((n, s) => n + s.chars, 0)
+  const diff = samples.reduce((n, s) => n + s.diff[mode], 0)
+  const shown = onlyDiff ? samples.filter((s) => s.diff[mode] > 0) : samples
+
+  return (
+    <div className="min-h-screen bg-bg text-fg">
+      <InternalHeader
+        className="px-6 pt-10 pb-6"
+        crumbs={[{ label: "Highlight compare" }]}
+        title="Highlight compare"
+        description="Runtime TSX highlighting: shiki (old, left) vs sugar-high (new, right). Characters whose color differs are marked in the right column."
+        actions={
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant={mode === "light" ? "primary" : "secondary"}
+              onPress={() => setMode("light")}
+            >
+              Light
+            </Button>
+            <Button
+              size="sm"
+              variant={mode === "dark" ? "primary" : "secondary"}
+              onPress={() => setMode("dark")}
+            >
+              Dark
+            </Button>
+            <Button
+              size="sm"
+              variant={onlyDiff ? "primary" : "secondary"}
+              onPress={() => setOnlyDiff((v) => !v)}
+            >
+              Only differing
+            </Button>
+          </div>
+        }
+      />
+      <div className="space-y-10 px-6 pb-24">
+        <p className="text-sm text-fg-muted">
+          {samples.length} playground files · {total} characters · {diff}{" "}
+          colored differently ({((100 * diff) / total).toFixed(1)}%) in {mode}{" "}
+          mode.
+        </p>
+        <table className="text-sm">
+          <thead className="text-left text-fg-muted">
+            <tr>
+              <th className="pr-6 font-medium">file</th>
+              <th className="pr-6 font-medium">chars</th>
+              <th className="pr-6 font-medium">light</th>
+              <th className="pr-6 font-medium">dark</th>
+            </tr>
+          </thead>
+          <tbody className="font-mono text-[0.8125rem]">
+            {samples.map((s) => (
+              <tr key={s.name}>
+                <td className="pr-6">
+                  <a href={`#${s.name}`}>{s.name}</a>
+                </td>
+                <td className="pr-6 tabular-nums">{s.chars}</td>
+                <td className="pr-6 tabular-nums">
+                  {s.diff.light} ({((100 * s.diff.light) / s.chars).toFixed(1)}
+                  %)
+                </td>
+                <td className="pr-6 tabular-nums">
+                  {s.diff.dark} ({((100 * s.diff.dark) / s.chars).toFixed(1)}%)
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div
+          data-mode={mode}
+          className="space-y-8 **:[mark.mismatch]:rounded-xs **:[mark.mismatch]:bg-transparent **:[mark.mismatch]:text-inherit **:[mark.mismatch]:outline-1 **:[mark.mismatch]:outline-red-500"
+        >
+          {shown.map((s) => (
+            <section key={s.name} id={s.name} className="space-y-2">
+              <h2 className="font-mono text-sm">
+                {s.name}/demos/playground.tsx ·{" "}
+                <span className="text-fg-muted">
+                  {s.diff[mode]} of {s.chars} differ
+                </span>
+              </h2>
+              <div
+                className="grid grid-cols-2 gap-4"
+                style={{ color: mode === "light" ? "#24292e" : "#e1e4e8" }}
+              >
+                <figure
+                  className="overflow-auto rounded-md border"
+                  style={{ background: mode === "light" ? "#fff" : "#24292e" }}
+                >
+                  {render(s.old)}
+                </figure>
+                <figure
+                  className="overflow-auto rounded-md border"
+                  style={{ background: mode === "light" ? "#fff" : "#24292e" }}
+                >
+                  {render(s.marked[mode])}
+                </figure>
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Runtime TSX highlighting (playground code, chart "Show code" modal, studio code-options preview, the composition animation) now runs on sugar-high instead of shiki. Build-time highlighting is untouched: fumadocs' `rehypeCode` and our `rehype-transform` still use shiki, which never ships to the browser and stays a dependency (fumadocs-core and shiki-magic-move peer on it).

## Why

The runtime highlighter graph (shiki core + JS regex engine + TSX grammar + two themes) was the single heaviest thing `DynamicPre` pulled into the docs, charts and studio chunks.

| | raw | gzip |
| --- | ---: | ---: |
| shiki runtime graph (before) | 418 KB | 79 KB |
| sugar-high core + typescript (after) | 12 KB | 4.3 KB |

## How it stays visually identical

sugar-high's token types are coarser than a TextMate grammar, so `highlight.ts` paints them with the github-light / github-dark palette and recovers the distinctions the theme cares about with small lookarounds (types after `:`, JSX tags, function/arrow parameters, operators, interface members, `type` as an object key…). It emits HAST in shiki's shape (`pre > code > span.line`, `--shiki-light` / `--shiki-dark` on every token) so the existing `<Pre>` styles render both, and the copy button keeps its newlines.

`highlight.test.ts` compares every non-whitespace character's color against shiki across all 51 playground demos and caps the mismatch at 1%. Current rate: **0.20%** in both themes (a few `const` names shiki paints as constants, one type alias, one nested default).

## Review aid (second commit, droppable)

`/internal/highlight-compare` renders every playground old vs new side by side, light or dark (`#dark`), with each differently-colored character outlined in red and a per-file mismatch table. Drop the commit before merge if you don't want it to live in `/internal`.

## Verification

- `pnpm check`, `tsc --noEmit` (www), `vitest run` on the new test.
- Docs playground, static blocks and copy text verified on the dev server (headless DOM dump); dynamic and static `<Button>` blocks come out with the same colors.
- The lockfile diff also carries a pnpm dedupe of already-present `@babel/*` / `unist-util-visit` versions — that's what `pnpm install` produces on this lockfile today.

## Suggested refactors

- `CompositionAnimation` (`www/src/modules/docs/composition-animation.tsx`, ~1400 lines) is mapped in `mdx-components.tsx` but no MDX page uses it, so it and shiki-magic-move sit in the docs chunk for nothing. Worth a separate delete-or-lazy-load PR.
