### PR TITLE
feat(www): move composition animation to an internal page

### DIFF
--- a/www/src/modules/docs/mdx-components.tsx
+++ b/www/src/modules/docs/mdx-components.tsx
@@ -13,7 +13,6 @@ import {
   CodeBlockTabsTrigger,
 } from "@/modules/docs/code-block-tabs"
 import { ComponentsGrid } from "@/modules/docs/components-list/components-grid"
-import { CompositionAnimation } from "@/modules/docs/composition-animation"
 import {
   Demo,
   DemoCode,
@@ -212,13 +211,4 @@ export const mdxComponents: MDXComponents = {
   ),
   ComponentsGrid,
   ChartFamilyGrid,
-  CompositionAnimation: ({
-    className,
-    ...props
-  }: React.ComponentProps<typeof CompositionAnimation>) => (
-    <CompositionAnimation
-      className={cn("not-first:mt-6", className)}
-      {...props}
-    />
-  ),
 }

--- a/www/src/modules/internal/composition-animation.tsx
+++ b/www/src/modules/internal/composition-animation.tsx
@@ -10,7 +10,6 @@ import {
   diffCleanupSemanticLossless,
   type Diff,
 } from "diff-match-patch-es"
-import { PauseIcon, PlayIcon } from "lucide-react"
 import { Pressable } from "react-aria-components/Pressable"
 import { syncTokenKeys, toKeyedTokens } from "shiki-magic-move/core"
 import { ShikiMagicMoveRenderer } from "shiki-magic-move/react"
@@ -24,7 +23,6 @@ import {
   MoreHorizontalIcon,
   SearchIcon,
 } from "@/registry/__generated__/icons"
-import { cn } from "@/registry/lib/utils"
 import { Avatar, AvatarFallback } from "@/registry/ui/avatar"
 import { Button } from "@/registry/ui/button"
 import { Calendar, RangeCalendar } from "@/registry/ui/calendar"
@@ -1563,7 +1561,7 @@ export function StepTimer({ player }: { player: CompositionPlayer }) {
       aria-hidden
       onAnimationEnd={advance}
       className="pointer-events-none fixed size-px opacity-0"
-      style={progressStyle(stepDurationMs, playing, "x")}
+      style={progressStyle(stepDurationMs, playing)}
     />
   )
 }
@@ -1571,107 +1569,15 @@ export function StepTimer({ player }: { player: CompositionPlayer }) {
 function progressStyle(
   durationMs: number,
   playing: boolean,
-  axis: "x" | "y",
 ): React.CSSProperties {
   return {
-    animationName: axis === "x" ? "cmp-progress-x" : "cmp-progress-y",
+    animationName: "cmp-progress-x",
     animationDuration: `${durationMs}ms`,
     animationTimingFunction: "linear",
     animationFillMode: "both",
     animationPlayState: playing ? "running" : "paused",
     willChange: "transform",
   }
-}
-
-// A track clipping a full-size bar that slides in via translate — scaling a
-// hairline bar re-rasterizes it every frame and visibly steps at slow speeds.
-export function StepProgress({
-  player,
-  axis = "x",
-  className,
-}: {
-  player: CompositionPlayer
-  axis?: "x" | "y"
-  className?: string
-}) {
-  const { step, stepDurationMs, playing, reducedMotion } = player
-  return (
-    <span key={step} aria-hidden className={cn("overflow-hidden", className)}>
-      <span
-        className="block size-full bg-fg"
-        style={
-          reducedMotion
-            ? undefined
-            : progressStyle(stepDurationMs, playing, axis)
-        }
-      />
-    </span>
-  )
-}
-
-export function StepDots({
-  player,
-  className,
-}: {
-  player: CompositionPlayer
-  className?: string
-}) {
-  const { paginated, activePaginated, goToStep } = player
-  return (
-    <div className={cn("flex items-center", className)}>
-      {paginated.map((p, pos) => (
-        <button
-          key={p.title}
-          type="button"
-          aria-label={`Step ${pos + 1}: ${p.title}`}
-          aria-current={pos === activePaginated ? "step" : undefined}
-          onClick={() => goToStep(p.index)}
-          className="group flex h-8 cursor-pointer items-center px-[3px]"
-        >
-          <span
-            className={cn(
-              "relative h-1 overflow-hidden rounded-full transition-all duration-300",
-              pos === activePaginated
-                ? "w-5 bg-border"
-                : "w-1.5 bg-border group-hover:bg-fg-muted",
-            )}
-          >
-            {pos === activePaginated && (
-              <StepProgress
-                player={player}
-                className="absolute inset-0 block rounded-full"
-              />
-            )}
-          </span>
-        </button>
-      ))}
-    </div>
-  )
-}
-
-export function PlayPauseButton({
-  player,
-  withLabel = false,
-  className,
-}: {
-  player: CompositionPlayer
-  withLabel?: boolean
-  className?: string
-}) {
-  const { paused, togglePlay } = player
-  return (
-    <Button
-      size="sm"
-      variant="quiet"
-      isIconOnly={!withLabel}
-      aria-label={paused ? "Play steps" : "Pause steps"}
-      onPress={togglePlay}
-      className={cn("text-fg-muted", className)}
-    >
-      {paused ? <PlayIcon /> : <PauseIcon />}
-      {withLabel && (paused ? "Play" : "Pause")}
-    </Button>
-  )
 }
 
 export function CompositionTransitionStyles({
@@ -1692,7 +1598,6 @@ export function CompositionTransitionStyles({
         animation-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1);
       }
       @keyframes cmp-progress-x { from { transform: translateX(-100%); } to { transform: translateX(0); } }
-      @keyframes cmp-progress-y { from { transform: translateY(-100%); } to { transform: translateY(0); } }
     `}</style>
   )
 }

--- a/www/src/modules/internal/composition-animation.tsx
+++ b/www/src/modules/internal/composition-animation.tsx
@@ -835,7 +835,7 @@ const paginate = (list: Step[]) =>
 const paginatedSteps = paginate(steps)
 const compactPaginatedSteps = paginate(compactSteps)
 
-export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
+type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 
 // shiki-magic-move delays each phase by a *fraction of* `duration` and then runs
 // it for a further 1×duration. Enter is last, so a transition ends at
@@ -853,7 +853,7 @@ const CODE_STAGGER_MS = 2
 // `compactBelowLg` swaps in the compact loop when the viewport is under the
 // lg breakpoint. It flips after mount only, so server and hydration markup
 // always show the full list's first step.
-export function useCompositionPlayer({ compactBelowLg = false } = {}) {
+function useCompositionPlayer({ compactBelowLg = false } = {}) {
   const [step, setStep] = useState(0)
   const [compact, setCompact] = useState(false)
   const [userPaused, setUserPaused] = useState(false)
@@ -1019,7 +1019,7 @@ export function useCompositionPlayer({ compactBelowLg = false } = {}) {
 // exactly one per player — onAnimationEnd is what advances the sequence, so
 // the decorative progress bars (same animation, same play state) stay in sync
 // with the actual tick by construction.
-export function StepTimer({ player }: { player: CompositionPlayer }) {
+function StepTimer({ player }: { player: CompositionPlayer }) {
   const { step, stepDurationMs, playing, advance, reducedMotion } = player
   if (reducedMotion) return null
   return (
@@ -1050,7 +1050,7 @@ function progressStyle(
 
 // A track clipping a full-size bar that slides in via translate — scaling a
 // hairline bar re-rasterizes it every frame and visibly steps at slow speeds.
-export function StepProgress({
+function StepProgress({
   player,
   axis = "x",
   className,
@@ -1074,7 +1074,7 @@ export function StepProgress({
   )
 }
 
-export function StepDots({
+function StepDots({
   player,
   className,
 }: {
@@ -1114,7 +1114,7 @@ export function StepDots({
   )
 }
 
-export function PlayPauseButton({
+function PlayPauseButton({
   player,
   withLabel = false,
   className,
@@ -1139,7 +1139,7 @@ export function PlayPauseButton({
   )
 }
 
-export function CompositionTransitionStyles({
+function CompositionTransitionStyles({
   morphMs = 450,
 }: { morphMs?: number } = {}) {
   return (
@@ -1314,7 +1314,7 @@ function keyedTokens(code: string, theme: "light" | "dark"): KeyedTokensInfo {
 
 // The gutter is sized for the loop's longest snippet, so it can't widen at line
 // 10 and shift the code sideways mid-transition.
-export const lineNumberWidth = String(maxCodeLines).length
+const lineNumberWidth = String(maxCodeLines).length
 
 // Line numbers are injected after the key sync rather than through the
 // library's `lineNumbers` option: the numbers stay out of the code's diff (which
@@ -1344,7 +1344,7 @@ function withLineNumbers(info: KeyedTokensInfo): KeyedTokensInfo {
   return { ...info, tokens }
 }
 
-export function CompositionCode({
+function CompositionCode({
   code,
   reducedMotion,
   duration = CODE_DURATION_MS,

--- a/www/src/modules/internal/composition-animation.tsx
+++ b/www/src/modules/internal/composition-animation.tsx
@@ -66,15 +66,72 @@ interface Step {
   durationMs: number
   code: string
   preview: React.ReactNode
+  // Short transitional beat that plays during auto-advance but isn't a
+  // clickable stop in the pagination (e.g. building an InputGroup addon by
+  // addon before landing on the headline step).
+  mid?: boolean
   // Part of the compact loop played when the home section stacks vertically —
   // only steps within a few code lines of each other, so the pane height
   // barely moves (see compactSteps).
   compact?: boolean
 }
 
+// Opening mid beat: a bare Input, the seed the TextField builds around. It's
+// the first frame on load, so it dwells a touch longer than the mids after it.
+const firstStep: Step = {
+  title: "TextField",
+  mid: true,
+  durationMs: 2000,
+  code: `<Input placeholder="hello@example.com" />`,
+  preview: (
+    <Input
+      aria-label="Email"
+      placeholder="hello@example.com"
+      className="w-full max-w-xs [view-transition-name:cmp-field]"
+    />
+  ),
+}
+
 const steps: Step[] = [
+  firstStep,
   {
-    // The full field — label, input, and description.
+    // Mid beat: wrap the bare input in a TextField — no field parts yet.
+    title: "TextField",
+    mid: true,
+    durationMs: 1400,
+    code: `<TextField>
+  <Input placeholder="hello@example.com" />
+</TextField>`,
+    preview: (
+      <TextField aria-label="Email" className="w-full max-w-xs">
+        <Input
+          placeholder="hello@example.com"
+          className="[view-transition-name:cmp-field]"
+        />
+      </TextField>
+    ),
+  },
+  {
+    // Mid beat: the field gains its label.
+    title: "TextField",
+    mid: true,
+    durationMs: 1400,
+    code: `<TextField>
+  <Label>Email</Label>
+  <Input placeholder="hello@example.com" />
+</TextField>`,
+    preview: (
+      <TextField className="w-full max-w-xs">
+        <Label className="[view-transition-name:cmp-label]">Email</Label>
+        <Input
+          placeholder="hello@example.com"
+          className="[view-transition-name:cmp-field]"
+        />
+      </TextField>
+    ),
+  },
+  {
+    // Headline: the full field — label, input, and description.
     title: "TextField",
     durationMs: 3000,
     code: `<TextField>
@@ -96,7 +153,61 @@ const steps: Step[] = [
     ),
   },
   {
-    // The same field, its input now an InputGroup with icon and action addons.
+    // Mid beat: wrap the input in an InputGroup — no addons yet.
+    title: "InputGroup",
+    mid: true,
+    durationMs: 1400,
+    code: `<TextField>
+  <Label>Email</Label>
+  <InputGroup>
+    <Input placeholder="hello@example.com" />
+  </InputGroup>
+  <Description>No spam, unsubscribe anytime.</Description>
+</TextField>`,
+    preview: (
+      <TextField className="w-full max-w-xs">
+        <Label className="[view-transition-name:cmp-label]">Email</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <Input placeholder="hello@example.com" />
+        </InputGroup>
+        <Description className="[view-transition-name:cmp-desc]">
+          No spam, unsubscribe anytime.
+        </Description>
+      </TextField>
+    ),
+  },
+  {
+    // Mid beat: add the leading addon.
+    title: "InputGroup",
+    mid: true,
+    durationMs: 1400,
+    code: `<TextField>
+  <Label>Email</Label>
+  <InputGroup>
+    <InputGroupAddon>
+      <MailIcon />
+    </InputGroupAddon>
+    <Input placeholder="hello@example.com" />
+  </InputGroup>
+  <Description>No spam, unsubscribe anytime.</Description>
+</TextField>`,
+    preview: (
+      <TextField className="w-full max-w-xs">
+        <Label className="[view-transition-name:cmp-label]">Email</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <InputGroupAddon>
+            <MailIcon />
+          </InputGroupAddon>
+          <Input placeholder="hello@example.com" />
+        </InputGroup>
+        <Description className="[view-transition-name:cmp-desc]">
+          No spam, unsubscribe anytime.
+        </Description>
+      </TextField>
+    ),
+  },
+  {
+    // Headline step: add the trailing addon — the full InputGroup.
     title: "InputGroup",
     compact: true,
     durationMs: 3600,
@@ -195,7 +306,45 @@ const steps: Step[] = [
     ),
   },
   {
-    // Attach the popover calendar.
+    // Mid beat: promote to DatePicker — move the icon to a trailing trigger,
+    // still no popover.
+    title: "DatePicker",
+    mid: true,
+    durationMs: 1400,
+    code: `<DatePicker>
+  <Label>Meeting date</Label>
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+</DatePicker>`,
+    preview: (
+      <DatePicker
+        className="w-full max-w-xs"
+        defaultValue={parseDate("2026-07-10")}
+      >
+        <Label className="[view-transition-name:cmp-label]">Meeting date</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+      </DatePicker>
+    ),
+  },
+  {
+    // Headline: attach the popover calendar.
     title: "DatePicker",
     durationMs: 3400,
     code: `<DatePicker>
@@ -241,7 +390,59 @@ const steps: Step[] = [
     ),
   },
   {
-    // The field gains its end date.
+    // Mid beat: promote to a range — Calendar → RangeCalendar, one input still.
+    // The snippet defers the slots to the headline beat; the preview needs
+    // slot="start" at runtime.
+    title: "DateRangePicker",
+    mid: true,
+    durationMs: 1400,
+    code: `<DateRangePicker>
+  <Label>Trip dates</Label>
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <DialogContent>
+      <RangeCalendar />
+    </DialogContent>
+  </Popover>
+</DateRangePicker>`,
+    preview: (
+      <DateRangePicker
+        className="w-full max-w-xs"
+        defaultValue={{
+          start: parseDate("2026-07-10"),
+          end: parseDate("2026-07-17"),
+        }}
+      >
+        <Label className="[view-transition-name:cmp-label]">Trip dates</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput slot="start" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <RangeCalendar />
+          </DialogContent>
+        </Popover>
+      </DateRangePicker>
+    ),
+  },
+  {
+    // Headline: the field gains its end date.
     title: "DateRangePicker",
     durationMs: 3400,
     code: `<DateRangePicker>
@@ -290,6 +491,61 @@ const steps: Step[] = [
             <RangeCalendar />
           </DialogContent>
         </Popover>
+      </DateRangePicker>
+    ),
+  },
+  {
+    // Mid beat: swap the overlay primitive — one word, Popover → Modal.
+    title: "Modal",
+    mid: true,
+    // 110 tokens: the transition needs ~1410ms to land (see CODE_SPAN).
+    durationMs: 1500,
+    code: `<DateRangePicker>
+  <Label>Trip dates</Label>
+  <InputGroup>
+    <DateInput slot="start" />
+    <span>–</span>
+    <DateInput slot="end" />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Modal>
+    <DialogContent>
+      <RangeCalendar />
+    </DialogContent>
+  </Modal>
+</DateRangePicker>`,
+    preview: (
+      <DateRangePicker
+        className="w-full max-w-xs"
+        defaultValue={{
+          start: parseDate("2026-07-10"),
+          end: parseDate("2026-07-17"),
+        }}
+      >
+        <Label className="[view-transition-name:cmp-label]">Trip dates</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput slot="start" />
+          <span>–</span>
+          <DateInput slot="end" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Modal>
+          <DialogContent>
+            <RangeCalendar />
+          </DialogContent>
+        </Modal>
       </DateRangePicker>
     ),
   },
@@ -346,7 +602,32 @@ const steps: Step[] = [
     ),
   },
   {
-    // Same trigger-plus-popover shape, now holding a list of options.
+    // Mid beat: collapse to a bare Select — label and trigger only.
+    title: "Select",
+    mid: true,
+    durationMs: 1300,
+    code: `<Select>
+  <Label>Assignee</Label>
+  <Button>
+    <SelectValue />
+    <ChevronDownIcon />
+  </Button>
+</Select>`,
+    preview: (
+      // defaultSelectedKey is mount-only, and the headline's Select updates
+      // this same instance in place — so the selection must start here, even
+      // though there are no items to resolve it against yet.
+      <Select className="w-full max-w-xs" defaultSelectedKey="cara">
+        <Label className="[view-transition-name:cmp-label]">Assignee</Label>
+        <Button className="[view-transition-name:cmp-field]">
+          <SelectValue />
+          <ChevronDownIcon />
+        </Button>
+      </Select>
+    ),
+  },
+  {
+    // Headline: attach the options list.
     title: "Select",
     compact: true,
     durationMs: 3200,
@@ -382,7 +663,7 @@ const steps: Step[] = [
     ),
   },
   {
-    // Same list, now a typeahead — swap the trigger for an input.
+    // Headline: same list, now a typeahead — swap the trigger for an input.
     title: "Combobox",
     durationMs: 3200,
     code: `<Combobox>
@@ -429,7 +710,7 @@ const steps: Step[] = [
     ),
   },
   {
-    // Multi-select — selected people surface as tags.
+    // Headline: multi-select — selected people surface as tags.
     title: "Tags",
     durationMs: 3000,
     code: `<Combobox>
@@ -488,7 +769,90 @@ const steps: Step[] = [
     ),
   },
   {
-    // The same popover list behind an icon trigger, one item nesting a submenu.
+    // Mid beat: a plain menu off an icon button.
+    title: "Menu",
+    mid: true,
+    durationMs: 1400,
+    code: `<Menu>
+  <Button size="sm" isIconOnly>
+    <MoreHorizontalIcon />
+  </Button>
+  <Popover>
+    <MenuContent>
+      <MenuItem>Edit</MenuItem>
+      <MenuItem>Duplicate</MenuItem>
+      <MenuItem>Delete</MenuItem>
+    </MenuContent>
+  </Popover>
+</Menu>`,
+    preview: (
+      <Menu>
+        <Button
+          size="sm"
+          isIconOnly
+          aria-label="Actions"
+          className="[view-transition-name:cmp-trigger]"
+        >
+          <MoreHorizontalIcon />
+        </Button>
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            <MenuItem>Edit</MenuItem>
+            <MenuItem>Duplicate</MenuItem>
+            <MenuItem>Delete</MenuItem>
+          </MenuContent>
+        </Popover>
+      </Menu>
+    ),
+  },
+  {
+    // Mid beat: the items gain keyboard shortcuts.
+    title: "Menu",
+    mid: true,
+    durationMs: 1400,
+    code: `<Menu>
+  <Button size="sm" isIconOnly>
+    <MoreHorizontalIcon />
+  </Button>
+  <Popover>
+    <MenuContent>
+      <MenuItem>Edit <Kbd>⌘E</Kbd></MenuItem>
+      <MenuItem>Duplicate <Kbd>⌘D</Kbd></MenuItem>
+      <MenuItem>Delete <Kbd>⌘⌫</Kbd></MenuItem>
+    </MenuContent>
+  </Popover>
+</Menu>`,
+    preview: (
+      <Menu>
+        <Button
+          size="sm"
+          isIconOnly
+          aria-label="Actions"
+          className="[view-transition-name:cmp-trigger]"
+        >
+          <MoreHorizontalIcon />
+        </Button>
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            <MenuItem textValue="Edit">
+              Edit
+              <Kbd>⌘E</Kbd>
+            </MenuItem>
+            <MenuItem textValue="Duplicate">
+              Duplicate
+              <Kbd>⌘D</Kbd>
+            </MenuItem>
+            <MenuItem textValue="Delete">
+              Delete
+              <Kbd>⌘⌫</Kbd>
+            </MenuItem>
+          </MenuContent>
+        </Popover>
+      </Menu>
+    ),
+  },
+  {
+    // Headline: one item nests a submenu.
     title: "Menu",
     compact: true,
     durationMs: 3000,
@@ -608,7 +972,40 @@ const steps: Step[] = [
     ),
   },
   {
-    // The same menu again, this time raised by typing @ in a textarea.
+    // Mid beat: the same menu, filtered by an @-mention typed into a textarea.
+    title: "Mention",
+    mid: true,
+    durationMs: 1500,
+    code: `<Mention>
+  <TextField>
+    <Label>Comment</Label>
+    <TextArea placeholder="Type @ to mention…" />
+  </TextField>
+  <Popover>
+    <MenuContent>
+      <MenuItem>Alex Miller</MenuItem>
+      <MenuItem>Sarah Jones</MenuItem>
+    </MenuContent>
+  </Popover>
+</Mention>`,
+    preview: (
+      <Mention className="w-full max-w-xs">
+        <TextField>
+          <Label className="[view-transition-name:cmp-label]">Comment</Label>
+          <TextArea placeholder="Type @ to mention…" />
+        </TextField>
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            {/* Ids are the full names — Mention inserts String(key) on select. */}
+            <MenuItem id="Alex Miller">Alex Miller</MenuItem>
+            <MenuItem id="Sarah Jones">Sarah Jones</MenuItem>
+          </MenuContent>
+        </Popover>
+      </Mention>
+    ),
+  },
+  {
+    // Headline: each suggestion gains an avatar.
     title: "Mention",
     durationMs: 3200,
     code: `<Mention>
@@ -652,6 +1049,79 @@ const steps: Step[] = [
           </MenuContent>
         </Popover>
       </Mention>
+    ),
+  },
+  {
+    // Mid beat: the command palette skeleton — a search input inside Command.
+    title: "Command",
+    mid: true,
+    durationMs: 1400,
+    code: `<Command>
+  <SearchField>
+    <InputGroup>
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <Input placeholder="Type a command…" />
+    </InputGroup>
+  </SearchField>
+</Command>`,
+    preview: (
+      <div className="w-full max-w-xs overflow-hidden rounded-md border bg-bg">
+        <Command aria-label="Command menu">
+          <SearchField aria-label="Search">
+            <InputGroup className="[view-transition-name:cmp-field]">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <Input placeholder="Type a command…" />
+            </InputGroup>
+          </SearchField>
+        </Command>
+      </div>
+    ),
+  },
+  {
+    // Mid beat: the palette gains its list of commands.
+    title: "Command",
+    mid: true,
+    durationMs: 1500,
+    code: `<Command>
+  <SearchField>
+    <InputGroup>
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <Input placeholder="Type a command…" />
+    </InputGroup>
+  </SearchField>
+  <ListBox>
+    <ListBoxItem>New issue</ListBoxItem>
+    <ListBoxItem>Assign to…</ListBoxItem>
+    <ListBoxItem>Search docs</ListBoxItem>
+  </ListBox>
+</Command>`,
+    preview: (
+      <div className="w-full max-w-xs overflow-hidden rounded-md border bg-bg">
+        <Command aria-label="Command menu">
+          <SearchField aria-label="Search">
+            <InputGroup className="[view-transition-name:cmp-field]">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <Input placeholder="Type a command…" />
+            </InputGroup>
+          </SearchField>
+          <ListBox
+            aria-label="Commands"
+            className="[view-transition-name:cmp-list]"
+          >
+            <ListBoxItem id="new-issue">New issue</ListBoxItem>
+            <ListBoxItem id="assign">Assign to…</ListBoxItem>
+            <ListBoxItem id="search-docs">Search docs</ListBoxItem>
+          </ListBox>
+        </Command>
+      </div>
     ),
   },
   {
@@ -828,22 +1298,34 @@ const steps: Step[] = [
 const compactSteps = steps.filter((s) => s.compact)
 const maxCodeLines = Math.max(...steps.map((s) => s.code.split("\n").length))
 
-// Each entry keeps its index into its list so the rail/dots can jump straight
-// to it.
+// Pagination lists only the headline steps; mid steps play during auto-advance
+// but aren't clickable stops. Each entry keeps its index into its list so the
+// rail/dots can jump straight to it.
 const paginate = (list: Step[]) =>
-  list.map((s, index) => ({ title: s.title, index }))
+  list
+    .map((s, index) => ({ title: s.title, index, mid: s.mid }))
+    .filter((s) => !s.mid)
 const paginatedSteps = paginate(steps)
 const compactPaginatedSteps = paginate(compactSteps)
 
-type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
+export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 
 // shiki-magic-move delays each phase by a *fraction of* `duration` and then runs
 // it for a further 1×duration. Enter is last, so a transition ends at
 // (1 + delayEnter)×duration + the stagger tail — not at `duration`. Every dwell
 // above has to clear that, or the next step cuts the animation off mid-flight.
 const CODE_ENTER_DELAY = 0.7
+const CODE_SPAN = 1 + CODE_ENTER_DELAY
 const CODE_DURATION_MS = 700
 const CODE_STAGGER_MS = 2
+
+// A manual walk plays the exact same code transition as auto-play, only with a
+// smaller stagger — so each beat must clear the full span plus the stagger tail
+// of the longest (~120-token) snippet.
+const WALK_CODE_STAGGER_MS = 0.5
+const MANUAL_BEAT_MS = Math.ceil(
+  CODE_SPAN * CODE_DURATION_MS + 120 * WALK_CODE_STAGGER_MS,
+)
 
 // Shared player: auto-advance while visible, with a CSS animation as the step
 // clock (see StepTimer) so the visible progress and the advance tick can never
@@ -853,7 +1335,7 @@ const CODE_STAGGER_MS = 2
 // `compactBelowLg` swaps in the compact loop when the viewport is under the
 // lg breakpoint. It flips after mount only, so server and hydration markup
 // always show the full list's first step.
-function useCompositionPlayer({ compactBelowLg = false } = {}) {
+export function useCompositionPlayer({ compactBelowLg = false } = {}) {
   const [step, setStep] = useState(0)
   const [compact, setCompact] = useState(false)
   const [userPaused, setUserPaused] = useState(false)
@@ -953,14 +1435,61 @@ function useCompositionPlayer({ compactBelowLg = false } = {}) {
     })
   }, [])
 
+  // Manual navigation (rail/dots): when the target is the next headline, play
+  // the mid beats between here and there on a fast cadence instead of
+  // hard-jumping, so the code still arrives in small blocks. Backward jumps
+  // and far jumps (crossing another headline) stay direct.
+  const walkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelWalk = useCallback(() => {
+    if (walkTimerRef.current) {
+      clearTimeout(walkTimerRef.current)
+      walkTimerRef.current = null
+    }
+  }, [])
+  useEffect(() => cancelWalk, [cancelWalk])
+
   // Restart from the top when the step list swaps (breakpoint cross) — the
   // current index points into the other list.
   useEffect(() => {
+    cancelWalk()
     stepRef.current = 0
     setStep(0)
-  }, [compact])
+  }, [compact, cancelWalk])
 
-  const goToStep = applyStep
+  const [walking, setWalking] = useState(false)
+  const goToStep = useCallback(
+    (next: number) => {
+      cancelWalk()
+      const from = stepRef.current
+      const between = activeSteps.slice(from + 1, next)
+      const reduce = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches
+      if (
+        reduce ||
+        next <= from ||
+        between.length === 0 ||
+        !between.every((s) => s.mid)
+      ) {
+        setWalking(false)
+        applyStep(next)
+        return
+      }
+      setWalking(true)
+      const walk = () => {
+        applyStep(stepRef.current + 1)
+        if (stepRef.current < next) {
+          walkTimerRef.current = setTimeout(walk, MANUAL_BEAT_MS)
+        } else {
+          // Clears in the same commit as the final step, so the arrival plays at
+          // full duration — nothing follows it to cut it off.
+          setWalking(false)
+        }
+      }
+      walk()
+    },
+    [applyStep, cancelWalk, activeSteps],
+  )
 
   const advance = useCallback(
     () => applyStep((stepRef.current + 1) % activeSteps.length),
@@ -982,8 +1511,13 @@ function useCompositionPlayer({ compactBelowLg = false } = {}) {
   // The index may briefly outlive a list swap — the reset effect above hasn't
   // run yet on that render.
   const current =
-    activeSteps[Math.min(step, activeSteps.length - 1)] ?? activeSteps[0]!
-  const activePaginated = Math.min(step, paginated.length - 1)
+    activeSteps[Math.min(step, activeSteps.length - 1)] ?? firstStep
+  // A mid step maps to the headline step it's building toward (the next
+  // paginated entry), so that entry stays lit while the beats play.
+  const activePaginated = Math.max(
+    0,
+    paginated.findIndex((p) => p.index >= step),
+  )
   const stepDurationMs = current.durationMs
   const reducedMotion =
     mounted && window.matchMedia("(prefers-reduced-motion: reduce)").matches
@@ -1012,6 +1546,7 @@ function useCompositionPlayer({ compactBelowLg = false } = {}) {
     reducedMotion,
     paginated,
     activePaginated,
+    codeStaggerMs: walking ? WALK_CODE_STAGGER_MS : CODE_STAGGER_MS,
   }
 }
 
@@ -1019,7 +1554,7 @@ function useCompositionPlayer({ compactBelowLg = false } = {}) {
 // exactly one per player — onAnimationEnd is what advances the sequence, so
 // the decorative progress bars (same animation, same play state) stay in sync
 // with the actual tick by construction.
-function StepTimer({ player }: { player: CompositionPlayer }) {
+export function StepTimer({ player }: { player: CompositionPlayer }) {
   const { step, stepDurationMs, playing, advance, reducedMotion } = player
   if (reducedMotion) return null
   return (
@@ -1050,7 +1585,7 @@ function progressStyle(
 
 // A track clipping a full-size bar that slides in via translate — scaling a
 // hairline bar re-rasterizes it every frame and visibly steps at slow speeds.
-function StepProgress({
+export function StepProgress({
   player,
   axis = "x",
   className,
@@ -1074,7 +1609,7 @@ function StepProgress({
   )
 }
 
-function StepDots({
+export function StepDots({
   player,
   className,
 }: {
@@ -1114,7 +1649,7 @@ function StepDots({
   )
 }
 
-function PlayPauseButton({
+export function PlayPauseButton({
   player,
   withLabel = false,
   className,
@@ -1139,7 +1674,7 @@ function PlayPauseButton({
   )
 }
 
-function CompositionTransitionStyles({
+export function CompositionTransitionStyles({
   morphMs = 450,
 }: { morphMs?: number } = {}) {
   return (
@@ -1314,7 +1849,7 @@ function keyedTokens(code: string, theme: "light" | "dark"): KeyedTokensInfo {
 
 // The gutter is sized for the loop's longest snippet, so it can't widen at line
 // 10 and shift the code sideways mid-transition.
-const lineNumberWidth = String(maxCodeLines).length
+export const lineNumberWidth = String(maxCodeLines).length
 
 // Line numbers are injected after the key sync rather than through the
 // library's `lineNumbers` option: the numbers stay out of the code's diff (which
@@ -1344,7 +1879,7 @@ function withLineNumbers(info: KeyedTokensInfo): KeyedTokensInfo {
   return { ...info, tokens }
 }
 
-function CompositionCode({
+export function CompositionCode({
   code,
   reducedMotion,
   duration = CODE_DURATION_MS,
@@ -1398,53 +1933,10 @@ function CompositionCode({
       options={{
         duration: reducedMotion ? 0 : duration,
         stagger,
+        // Pinned: CODE_SPAN is only correct if this is what the renderer uses.
         delayEnter: CODE_ENTER_DELAY,
         containerStyle: false,
       }}
     />
-  )
-}
-
-export function CompositionAnimation({ className }: { className?: string }) {
-  const player = useCompositionPlayer()
-  const { mounted, containerRef, current, reducedMotion, setHoverPaused } =
-    player
-
-  return (
-    <div
-      ref={containerRef}
-      className={cn("overflow-hidden rounded-md border bg-card", className)}
-      onMouseEnter={() => setHoverPaused(true)}
-      onMouseLeave={() => setHoverPaused(false)}
-      onFocus={() => setHoverPaused(true)}
-      onBlur={() => setHoverPaused(false)}
-    >
-      <CompositionTransitionStyles />
-      <StepTimer player={player} />
-      <div className="flex items-center justify-between gap-2 border-b py-1.5 pr-1.5 pl-2.5">
-        <span className="truncate font-mono text-[0.8125rem] text-fg-muted">
-          {current.title}
-        </span>
-        <div className="flex items-center gap-1">
-          <StepDots player={player} />
-          <PlayPauseButton player={player} />
-        </div>
-      </div>
-      <div className="grid sm:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
-        <div className="no-scrollbar h-88 overflow-auto p-4 font-mono text-[0.8125rem] leading-relaxed">
-          {mounted ? (
-            <CompositionCode
-              code={current.code}
-              reducedMotion={reducedMotion}
-            />
-          ) : (
-            <pre className="whitespace-pre">{current.code}</pre>
-          )}
-        </div>
-        <div className="flex min-h-40 items-center justify-center border-t bg-bg p-6 sm:border-t-0 sm:border-l">
-          {current.preview}
-        </div>
-      </div>
-    </div>
   )
 }

--- a/www/src/modules/internal/composition-section.tsx
+++ b/www/src/modules/internal/composition-section.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useRef, useState } from "react"
+
+import { cn } from "@/registry/lib/utils"
+import {
+  CompositionCode,
+  CompositionTransitionStyles,
+  lineNumberWidth,
+  PlayPauseButton,
+  StepDots,
+  StepTimer,
+  useCompositionPlayer,
+} from "@/modules/internal/composition-animation"
+
+// The right panel at its tallest step: the play/pause row (h-7 + mb-3) + the
+// preview area (min-h-56) + the code pane at its ceiling (max-h-86) + the card's
+// own y-borders. Reserving it on the panel's container keeps the animating card
+// from ever moving the page.
+const panelMaxHeight = "calc(2.5rem + 14rem + 21.5rem + 2px)"
+
+export function CompositionSection() {
+  const player = useCompositionPlayer({ compactBelowLg: true })
+  const {
+    paginated,
+    activePaginated,
+    goToStep,
+    setHoverPaused,
+    mounted,
+    containerRef,
+    current,
+    reducedMotion,
+    codeStaggerMs,
+  } = player
+
+  // Keep the active step centered in the fixed-height rail as the loop runs.
+  const railRef = useRef<HTMLOListElement>(null)
+  useEffect(() => {
+    const rail = railRef.current
+    const active = rail?.querySelectorAll("li")[activePaginated] as
+      | HTMLElement
+      | undefined
+    if (!rail || !active) return
+    rail.scrollTo({
+      top: active.offsetTop - rail.clientHeight / 2 + active.offsetHeight / 2,
+      behavior: reducedMotion ? "auto" : "smooth",
+    })
+  }, [activePaginated, reducedMotion])
+
+  // The code pane hugs its content. The target height is computed from the
+  // step's line count (calibrated once against the first rendered snippet) so
+  // the tween starts in the same commit as the token animation — observing the
+  // DOM instead would only fire after departing tokens are removed, i.e. late.
+  // Until calibration the height stays auto (auto→px doesn't tween).
+  const codeInnerRef = useRef<HTMLDivElement>(null)
+  const codeMetrics = useRef<{ line: number; pad: number } | null>(null)
+  const [codeHeight, setCodeHeight] = useState<number | null>(null)
+  useEffect(() => {
+    const el = codeInnerRef.current
+    if (!el || !mounted) return
+    const lines = current.code.split("\n").length
+    if (!codeMetrics.current) {
+      const style = getComputedStyle(el)
+      const pad = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
+      // Rect, not offsetHeight — the integer rounding inflates the per-line
+      // metric (67.5 → 68 reads as 20px/line instead of 19.5).
+      const height = el.getBoundingClientRect().height
+      codeMetrics.current = { line: (height - pad) / lines, pad }
+    }
+    const { line, pad } = codeMetrics.current
+    setCodeHeight(lines * line + pad)
+  }, [mounted, current.code])
+
+  const pauseHandlers = {
+    onMouseEnter: () => setHoverPaused(true),
+    onMouseLeave: () => setHoverPaused(false),
+    onFocus: () => setHoverPaused(true),
+    onBlur: () => setHoverPaused(false),
+  }
+
+  return (
+    <section>
+      <CompositionTransitionStyles />
+      <StepTimer player={player} />
+      <div
+        ref={containerRef}
+        className="grid items-start gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-16"
+      >
+        {/* Copy + step rail */}
+        <div className="flex flex-col items-start gap-4">
+          <h2 className="font-mono text-sm tracking-wide text-fg-muted">
+            Composition
+          </h2>
+          <p className="text-3xl font-semibold tracking-tighter text-balance sm:text-4xl">
+            Compose components.
+            <br />
+            <span className="text-fg-muted">Create your own patterns.</span>
+          </p>
+          <p className="text-base text-fg-muted lg:max-w-md">
+            One compositional API across the library — the same parts combine
+            into anything, from a simple field to a complex pattern.
+          </p>
+          <ol
+            ref={railRef}
+            className="relative mt-2 no-scrollbar h-80 max-w-54 self-stretch overflow-y-auto [mask-image:linear-gradient(to_bottom,transparent,black_3rem,black_calc(100%-3rem),transparent)] py-5 max-lg:hidden"
+            {...pauseHandlers}
+          >
+            {/* One indicator for the whole rail — it travels to the active
+                step instead of each step lighting its own segment. */}
+            <span
+              aria-hidden
+              className="absolute top-5 left-0 z-10 h-8 w-px bg-fg transition-transform ease-[cubic-bezier(0.645,0.045,0.355,1)] motion-reduce:transition-none"
+              style={{
+                transform: `translateY(${activePaginated * 2}rem)`,
+                transitionDuration: "450ms",
+              }}
+            />
+            {paginated.map((p, pos) => (
+              <li key={p.title}>
+                <button
+                  type="button"
+                  aria-current={pos === activePaginated ? "step" : undefined}
+                  onClick={() => goToStep(p.index)}
+                  className={cn(
+                    "relative flex h-8 w-full cursor-pointer items-center gap-3 border-l pl-4 text-left text-sm transition-colors",
+                    pos === activePaginated
+                      ? "text-fg"
+                      : "text-fg-muted hover:text-fg",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "font-mono text-xs tabular-nums transition-colors",
+                      pos === activePaginated
+                        ? "text-fg-muted"
+                        : "text-fg-muted/50",
+                    )}
+                  >
+                    {String(pos + 1).padStart(2, "0")}
+                  </span>
+                  {p.title}
+                </button>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        {/* Code with its rendered result below — one card, no window chrome.
+            On lg the container reserves the tallest step's height so the
+            animating card resizes inside it without moving the page. */}
+        {/* min-w-0: grid items floor at min-content, so the code would widen the
+            column past the viewport instead of scrolling inside the card. */}
+        <div
+          className="min-w-0 lg:min-h-(--panel-max)"
+          style={{ "--panel-max": panelMaxHeight } as React.CSSProperties}
+        >
+          {/* Title and dots stand in for the step rail, which is desktop-only.
+              The play/pause button stays at both sizes, and sits outside the
+              card: hovering the card is itself a pause, so a play button inside
+              it flips to "play" as you reach for it. */}
+          <div className="mb-3 flex items-center gap-1">
+            <span className="truncate font-mono text-xs text-fg-muted lg:hidden">
+              {current.title}
+            </span>
+            <StepDots player={player} className="ml-auto shrink-0 lg:hidden" />
+            <PlayPauseButton
+              player={player}
+              withLabel
+              // Pulled by the button's own padding, so the icon — not the hit
+              // area — lines up with the card's left edge.
+              className="shrink-0 lg:-ml-2.5"
+            />
+          </div>
+          <div
+            className="overflow-hidden rounded-xl border bg-card shadow-xs"
+            {...pauseHandlers}
+          >
+            <div className="relative flex min-h-56 items-center justify-center p-6">
+              <div
+                aria-hidden
+                className="absolute inset-0 bg-[radial-gradient(var(--color-border)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_70%_80%_at_50%_50%,black,transparent)] bg-[size:14px_14px]"
+              />
+              <div className="relative flex w-full justify-center">
+                {current.preview}
+              </div>
+            </div>
+            {/* The pane hugs its snippet between a floor and a ceiling; past the
+                ceiling the code scrolls, faded at whichever edge still has
+                code beyond it. Below lg, where the section stacks, it's pinned
+                instead — the page can't move between steps. */}
+            <div
+              className="no-scrollbar scroll-fade-y overflow-x-hidden overflow-y-auto overscroll-contain border-t transition-[height] ease-in-out scroll-fade-6 motion-reduce:transition-none max-lg:max-h-62 max-lg:min-h-62 lg:max-h-86 lg:min-h-51"
+              style={{
+                height: codeHeight ?? "auto",
+                transitionDuration: "500ms",
+              }}
+            >
+              <div
+                ref={codeInnerRef}
+                className="no-scrollbar scroll-fade-x overflow-x-auto p-6 font-mono text-[0.8125rem] leading-normal"
+              >
+                {mounted ? (
+                  <CompositionCode
+                    code={current.code}
+                    reducedMotion={reducedMotion}
+                    stagger={codeStaggerMs}
+                    lineNumbers
+                  />
+                ) : (
+                  // Carries the gutter too, so hydration doesn't shift the
+                  // snippet sideways.
+                  <pre className="whitespace-pre">
+                    {current.code.split("\n").map((line, i) => (
+                      <span key={i}>
+                        <span className="opacity-30">
+                          {`${String(i + 1).padStart(lineNumberWidth, " ")}  `}
+                        </span>
+                        {`${line}\n`}
+                      </span>
+                    ))}
+                  </pre>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/www/src/modules/internal/composition-section.tsx
+++ b/www/src/modules/internal/composition-section.tsx
@@ -5,17 +5,14 @@ import {
   CompositionCode,
   CompositionTransitionStyles,
   lineNumberWidth,
-  PlayPauseButton,
-  StepDots,
   StepTimer,
   useCompositionPlayer,
 } from "@/modules/internal/composition-animation"
 
-// The right panel at its tallest step: the play/pause row (h-7 + mb-3) + the
-// preview area (min-h-56) + the code pane at its ceiling (max-h-86) + the card's
-// own y-borders. Reserving it on the panel's container keeps the animating card
+// The panel at its tallest step: the preview area (min-h-56) + the code pane
+// at its ceiling (max-h-86) + the card's own y-borders. Reserving it on the panel's container keeps the animating card
 // from ever moving the page.
-const panelMaxHeight = "calc(2.5rem + 14rem + 21.5rem + 2px)"
+const panelMaxHeight = "calc(14rem + 21.5rem + 2px)"
 
 export function CompositionSection() {
   const player = useCompositionPlayer({ compactBelowLg: true })
@@ -84,23 +81,11 @@ export function CompositionSection() {
         ref={containerRef}
         className="grid items-start gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-16"
       >
-        {/* Copy + step rail */}
-        <div className="flex flex-col items-start gap-4">
-          <h2 className="font-mono text-sm tracking-wide text-fg-muted">
-            Composition
-          </h2>
-          <p className="text-3xl font-semibold tracking-tighter text-balance sm:text-4xl">
-            Compose components.
-            <br />
-            <span className="text-fg-muted">Create your own patterns.</span>
-          </p>
-          <p className="text-base text-fg-muted lg:max-w-md">
-            One compositional API across the library — the same parts combine
-            into anything, from a simple field to a complex pattern.
-          </p>
+        {/* Step rail */}
+        <div className="flex flex-col items-start">
           <ol
             ref={railRef}
-            className="relative mt-2 no-scrollbar h-80 max-w-54 self-stretch overflow-y-auto [mask-image:linear-gradient(to_bottom,transparent,black_3rem,black_calc(100%-3rem),transparent)] py-5 max-lg:hidden"
+            className="relative no-scrollbar h-80 max-w-54 self-stretch overflow-y-auto [mask-image:linear-gradient(to_bottom,transparent,black_3rem,black_calc(100%-3rem),transparent)] py-5"
             {...pauseHandlers}
           >
             {/* One indicator for the whole rail — it travels to the active
@@ -152,23 +137,6 @@ export function CompositionSection() {
           className="min-w-0 lg:min-h-(--panel-max)"
           style={{ "--panel-max": panelMaxHeight } as React.CSSProperties}
         >
-          {/* Title and dots stand in for the step rail, which is desktop-only.
-              The play/pause button stays at both sizes, and sits outside the
-              card: hovering the card is itself a pause, so a play button inside
-              it flips to "play" as you reach for it. */}
-          <div className="mb-3 flex items-center gap-1">
-            <span className="truncate font-mono text-xs text-fg-muted lg:hidden">
-              {current.title}
-            </span>
-            <StepDots player={player} className="ml-auto shrink-0 lg:hidden" />
-            <PlayPauseButton
-              player={player}
-              withLabel
-              // Pulled by the button's own padding, so the icon — not the hit
-              // area — lines up with the card's left edge.
-              className="shrink-0 lg:-ml-2.5"
-            />
-          </div>
           <div
             className="overflow-hidden rounded-xl border bg-card shadow-xs"
             {...pauseHandlers}

--- a/www/src/modules/internal/registry.ts
+++ b/www/src/modules/internal/registry.ts
@@ -30,6 +30,6 @@ export const INTERNAL_TOOLS: InternalTool[] = [
     href: "/internal/composition-animation",
     label: "Composition animation",
     description:
-      "The retired landing-page loop: magic-move code diffs synced with view-transitioned component previews.",
+      "The composition section retired from the landing page: code beats synced with view-transitioned component previews.",
   },
 ]

--- a/www/src/modules/internal/registry.ts
+++ b/www/src/modules/internal/registry.ts
@@ -26,4 +26,10 @@ export const INTERNAL_TOOLS: InternalTool[] = [
     description:
       "The blur-reveal utilities paired with ProgressiveBlur: root-scroll and nearest-scroller drivers.",
   },
+  {
+    href: "/internal/composition-animation",
+    label: "Composition animation",
+    description:
+      "The retired landing-page loop: magic-move code diffs synced with view-transitioned component previews.",
+  },
 ]

--- a/www/src/routeTree.gen.ts
+++ b/www/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as PreviewSlugRouteImport } from './routes/preview/$slug'
 import { Route as InternalRegistriesRouteImport } from './routes/internal.registries'
 import { Route as InternalPresetLabRouteImport } from './routes/internal.preset-lab'
 import { Route as InternalHighlightCompareRouteImport } from './routes/internal.highlight-compare'
+import { Route as InternalCompositionAnimationRouteImport } from './routes/internal.composition-animation'
 import { Route as InternalColorLabRouteImport } from './routes/internal.color-lab'
 import { Route as InternalBlurRevealRouteImport } from './routes/internal.blur-reveal'
 import { Route as DemosSlugRouteImport } from './routes/demos/$slug'
@@ -125,6 +126,12 @@ const InternalHighlightCompareRoute =
     path: '/internal/highlight-compare',
     getParentRoute: () => rootRouteImport,
   } as any)
+const InternalCompositionAnimationRoute =
+  InternalCompositionAnimationRouteImport.update({
+    id: '/internal/composition-animation',
+    path: '/internal/composition-animation',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InternalColorLabRoute = InternalColorLabRouteImport.update({
   id: '/internal/color-lab',
   path: '/internal/color-lab',
@@ -211,6 +218,7 @@ export interface FileRoutesByFullPath {
   '/demos/$slug': typeof DemosSlugRoute
   '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
+  '/internal/composition-animation': typeof InternalCompositionAnimationRoute
   '/internal/highlight-compare': typeof InternalHighlightCompareRoute
   '/internal/preset-lab': typeof InternalPresetLabRoute
   '/internal/registries': typeof InternalRegistriesRoute
@@ -241,6 +249,7 @@ export interface FileRoutesByTo {
   '/demos/$slug': typeof DemosSlugRoute
   '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
+  '/internal/composition-animation': typeof InternalCompositionAnimationRoute
   '/internal/highlight-compare': typeof InternalHighlightCompareRoute
   '/internal/preset-lab': typeof InternalPresetLabRoute
   '/internal/registries': typeof InternalRegistriesRoute
@@ -274,6 +283,7 @@ export interface FileRoutesById {
   '/demos/$slug': typeof DemosSlugRoute
   '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
+  '/internal/composition-animation': typeof InternalCompositionAnimationRoute
   '/internal/highlight-compare': typeof InternalHighlightCompareRoute
   '/internal/preset-lab': typeof InternalPresetLabRoute
   '/internal/registries': typeof InternalRegistriesRoute
@@ -308,6 +318,7 @@ export interface FileRouteTypes {
     | '/demos/$slug'
     | '/internal/blur-reveal'
     | '/internal/color-lab'
+    | '/internal/composition-animation'
     | '/internal/highlight-compare'
     | '/internal/preset-lab'
     | '/internal/registries'
@@ -338,6 +349,7 @@ export interface FileRouteTypes {
     | '/demos/$slug'
     | '/internal/blur-reveal'
     | '/internal/color-lab'
+    | '/internal/composition-animation'
     | '/internal/highlight-compare'
     | '/internal/preset-lab'
     | '/internal/registries'
@@ -370,6 +382,7 @@ export interface FileRouteTypes {
     | '/demos/$slug'
     | '/internal/blur-reveal'
     | '/internal/color-lab'
+    | '/internal/composition-animation'
     | '/internal/highlight-compare'
     | '/internal/preset-lab'
     | '/internal/registries'
@@ -397,6 +410,7 @@ export interface RootRouteChildren {
   DemosSlugRoute: typeof DemosSlugRoute
   InternalBlurRevealRoute: typeof InternalBlurRevealRoute
   InternalColorLabRoute: typeof InternalColorLabRoute
+  InternalCompositionAnimationRoute: typeof InternalCompositionAnimationRoute
   InternalHighlightCompareRoute: typeof InternalHighlightCompareRoute
   InternalPresetLabRoute: typeof InternalPresetLabRoute
   InternalRegistriesRoute: typeof InternalRegistriesRoute
@@ -527,6 +541,13 @@ declare module '@tanstack/react-router' {
       path: '/internal/highlight-compare'
       fullPath: '/internal/highlight-compare'
       preLoaderRoute: typeof InternalHighlightCompareRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/internal/composition-animation': {
+      id: '/internal/composition-animation'
+      path: '/internal/composition-animation'
+      fullPath: '/internal/composition-animation'
+      preLoaderRoute: typeof InternalCompositionAnimationRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/internal/color-lab': {
@@ -674,6 +695,7 @@ const rootRouteChildren: RootRouteChildren = {
   DemosSlugRoute: DemosSlugRoute,
   InternalBlurRevealRoute: InternalBlurRevealRoute,
   InternalColorLabRoute: InternalColorLabRoute,
+  InternalCompositionAnimationRoute: InternalCompositionAnimationRoute,
   InternalHighlightCompareRoute: InternalHighlightCompareRoute,
   InternalPresetLabRoute: InternalPresetLabRoute,
   InternalRegistriesRoute: InternalRegistriesRoute,

--- a/www/src/routes/internal.composition-animation.tsx
+++ b/www/src/routes/internal.composition-animation.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-import { CompositionAnimation } from "@/modules/internal/composition-animation"
+import { CompositionSection } from "@/modules/internal/composition-section"
 import { InternalShell } from "@/modules/internal/shell"
 
 export const Route = createFileRoute("/internal/composition-animation")({
@@ -13,9 +13,11 @@ function CompositionAnimationDemo() {
     <InternalShell
       crumbs={[{ label: "Composition animation" }]}
       title="Composition animation"
-      description="The code-to-preview composition loop that used to run on the landing page: magic-move code diffs synced with view-transitioned component previews."
+      description="The composition section retired from the landing page: 30 magic-move code beats synced with view-transitioned component previews, with the step rail on desktop and the compact loop when stacked."
     >
-      <CompositionAnimation className="max-w-4xl" />
+      <div className="max-w-6xl">
+        <CompositionSection />
+      </div>
     </InternalShell>
   )
 }

--- a/www/src/routes/internal.composition-animation.tsx
+++ b/www/src/routes/internal.composition-animation.tsx
@@ -13,7 +13,7 @@ function CompositionAnimationDemo() {
     <InternalShell
       crumbs={[{ label: "Composition animation" }]}
       title="Composition animation"
-      description="The composition section retired from the landing page: 30 magic-move code beats synced with view-transitioned component previews, with the step rail on desktop and the compact loop when stacked."
+      description="The composition loop retired from the landing page: 30 magic-move code beats synced with view-transitioned component previews. Hover to pause, click a step to jump."
     >
       <div className="max-w-6xl">
         <CompositionSection />

--- a/www/src/routes/internal.composition-animation.tsx
+++ b/www/src/routes/internal.composition-animation.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { CompositionAnimation } from "@/modules/internal/composition-animation"
+import { InternalShell } from "@/modules/internal/shell"
+
+export const Route = createFileRoute("/internal/composition-animation")({
+  component: CompositionAnimationDemo,
+  head: () => ({ meta: [{ title: "Composition animation · dotUI" }] }),
+})
+
+function CompositionAnimationDemo() {
+  return (
+    <InternalShell
+      crumbs={[{ label: "Composition animation" }]}
+      title="Composition animation"
+      description="The code-to-preview composition loop that used to run on the landing page: magic-move code diffs synced with view-transitioned component previews."
+    >
+      <CompositionAnimation className="max-w-4xl" />
+    </InternalShell>
+  )
+}


### PR DESCRIPTION
## Summary

- Move the composition animation out of `modules/docs` into `modules/internal` and serve it at `/internal/composition-animation`, listed on `/internal`.
- Remove the `CompositionAnimation` MDX component. No MDX page used it since the landing page rewrite, but `mdx-components.tsx` still imported it eagerly, so `shiki-magic-move`, `diff-match-patch-es` and the magic-move stylesheet shipped in the docs chunk.
- Restore the **full landing-page composition section** as it last shipped (c944a494e, before #624 trimmed the landing): 30 beats (16 headline steps + 14 walk-through mids), the numbered step rail, the dot-grid preview, the line-numbered tweened code pane and the compact stacked loop. The context-menu step stays on the current `Menu trigger="contextMenu"` API since the `context-menu` registry item was removed in #554. The trimmed docs card component is gone.

## Verification

- Production build: magic-move/diff code appears only in `internal.composition-animation-*.js`, its stylesheet only in `internal-*.css`. The `-docs-page-*.js` chunk no longer contains them.
- `pnpm check` and `pnpm typecheck` pass. `routeTree.gen.ts` regenerated by the build.
- Dev server: the section renders with rail, preview and code pane, and the loop walks through the mid beats. No new console errors (the occasional aborted view transition in a hidden tab predates this change).

Note: `highlight.ts` (shiki) stays in the docs chunk for the playground's `DynamicPre`; that's covered separately by #723.