### PR TITLE
ci: pin claude-code-action and Claude Code version

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ccc3a35a6367cdb8e6fbd0728287467540ecfe2 # v1.0.219 (Claude Code 2.1.266)
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ccc3a35a6367cdb8e6fbd0728287467540ecfe2 # v1.0.219 (Claude Code 2.1.266)
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Pins \`anthropics/claude-code-action\` to the v1.0.219 commit (Claude Code 2.1.266) in both workflows instead of the floating \`v1\` tag.

The \`claude-review\` job failed on every PR between 22:34 and 23:30 UTC on 2026-09-08, e.g. https://github.com/mehdibha/dotUI/actions/runs/34286608798: the installer reported \`claude command at /home/runner/.local/bin/claude missing or broken\` and the action then died with \`ENOENT ... posix_spawn '/home/runner/.local/bin/claude'\` while adding the plugin marketplace. The action has no \`claude_code_version\` input; the CLI version is hardcoded per action release, so pinning the action pins the CLI too.

Note: a passing run at 22:06 used the same action SHA and CLI version as the failing ones, so the break was in the runtime-fetched \`claude.ai/install.sh\`. The pin removes the action and CLI as moving parts but cannot pin that script; if it recurs, the next step is installing the CLI ourselves and passing \`path_to_claude_code_executable\`.