### PR TITLE
perf(www): regroup react-aria and base-ui chunks by entry

### DIFF
--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -39,6 +39,39 @@ export default defineConfig({
   define: {
     "import.meta.env.VERCEL_ENV": JSON.stringify(process.env.VERCEL_ENV ?? ""),
   },
+  environments: {
+    client: {
+      build: {
+        rolldownOptions: {
+          output: {
+            // Rolldown's default splitting merges react-aria and base-ui
+            // modules into coarse shared chunks, so every page downloads
+            // collection and overlay code only a few routes use. Regroup them
+            // by the set of entries that actually import each module.
+            codeSplitting: {
+              groups: [
+                {
+                  name: "react-aria",
+                  entriesAware: true,
+                  test: /[\\/](react-aria-components|react-aria|react-stately|@react-aria|@react-stately|@react-types|@internationalized)[\\/]/,
+                },
+                {
+                  name: "base-ui",
+                  entriesAware: true,
+                  test: /[\\/]@base-ui[\\/]/,
+                },
+              ],
+            },
+            // entriesAware names chunks after every entry that shares them.
+            chunkFileNames: (chunk) =>
+              /^(react-aria|base-ui)~/.test(chunk.name)
+                ? `assets/${chunk.name.split("~")[0]}-[hash].js`
+                : "assets/[name]-[hash].js",
+          },
+        },
+      },
+    },
+  },
   resolve: {
     alias: [
       {


### PR DESCRIPTION
> **Withdrawn — measured as a no-op once first-load follows static imports.** Left open as a draft for the record; close unless you want the chunk naming for another reason.

## What happened

Rolldown 1.1 `output.codeSplitting` groups with `entriesAware: true` for react-aria and base-ui looked like a −12–14% first-load win when measured on the HTML `modulepreload` list (`/` 337 → 289 KB gz). Rebased onto main after #731 and re-measured including every chunk's transitive static imports — what the browser actually fetches before the page runs — the difference disappears:

| page | main (listed / actual) | this PR (listed / actual) |
|---|---|---|
| `/` | 303.2 / **629.3** KB gz | 255.0 / **628.8** KB gz |
| `/docs/components/button` | 232.3 / **715.7** KB gz | 203.3 / **715.3** KB gz |
| `/studio` | 382.3 / **569.5** KB gz | 324.5 / **568.2** KB gz |

The regrouping only moved bytes out of the preload list into chunks that are then discovered through the import waterfall, which is worse for latency, not better. The real finding is the ~2× gap between the preload list and the static-import closure on every page (~326 KB gz on `/` not preloaded); #729's budget now measures the closure so this can't be mistaken for a win again.

Variants measured and rejected earlier: the literal #418 groups (`/` 337 → 579 KB listed, 667.7 KB actual) and `tags: ["$initial"]` (no-op — react-aria isn't statically reachable from the entry since #627).

Refs #395.
