### PR TITLE
perf(www): keep zod off the client color path

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -6,14 +6,16 @@
   "license": "MIT",
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./schema": "./src/schema.ts"
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "culori": "^4.0.2"
+    "culori": "^4.0.2",
+    "zod": "^4.2.1"
   },
   "devDependencies": {
     "@adobe/leonardo-contrast-colors": "^1.1.0",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -13,8 +13,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "culori": "^4.0.2",
-    "zod": "^4.2.1"
+    "culori": "^4.0.2"
   },
   "devDependencies": {
     "@adobe/leonardo-contrast-colors": "^1.1.0",

--- a/packages/colors/src/index.ts
+++ b/packages/colors/src/index.ts
@@ -13,9 +13,9 @@ export {
   createTheme,
   type ModeOutput,
   type Theme,
-  type ThemeOptions,
   type ThemeReport,
 } from "./theme"
+export type { ThemeOptions } from "./schema"
 
 export { STATUS_SEEDS, STEPS, type StatusName, type StepName } from "./data"
 

--- a/packages/colors/src/index.ts
+++ b/packages/colors/src/index.ts
@@ -13,7 +13,6 @@ export {
   createTheme,
   type ModeOutput,
   type Theme,
-  themeOptionsSchema,
   type ThemeOptions,
   type ThemeReport,
 } from "./theme"

--- a/packages/colors/src/schema.ts
+++ b/packages/colors/src/schema.ts
@@ -1,0 +1,92 @@
+/**
+ * The `createTheme` input contract as a zod schema — a build/test-time gate
+ * (registry build, tests, server-side publishing). Not imported by
+ * `createTheme` itself, so the client never ships zod; `ThemeOptions` is the
+ * inferred type and is all the engine needs at runtime.
+ */
+
+import { z } from "zod"
+
+import { toOklch } from "./space"
+
+const colorString = z.string().refine(
+  (value) => {
+    try {
+      toOklch(value)
+      return true
+    } catch {
+      return false
+    }
+  },
+  { message: "not a parsable CSS color" },
+)
+
+const borderTargetRatio = z.number().min(1.05).max(21)
+const borderTargetValue = z.union([
+  borderTargetRatio,
+  z.object({
+    light: borderTargetRatio.optional(),
+    dark: borderTargetRatio.optional(),
+  }),
+])
+
+export const themeOptionsSchema = z.object({
+  seeds: z
+    .object({
+      accent: colorString,
+      neutral: colorString.optional(),
+      success: colorString.optional(),
+      warning: colorString.optional(),
+      danger: colorString.optional(),
+      info: colorString.optional(),
+    })
+    .catchall(colorString),
+  /** D7 — pin the accent verbatim at the solid step; the report prices it. */
+  preserveSeed: z.boolean().optional(),
+  /** D5 — scales the fitted chroma curve (1 ≈ Radix, ~1.33 ≈ Tailwind). */
+  vividness: z.number().min(0).max(2).optional(),
+  /** D6 — scalar on the hue-band bend table (1.6 ≈ Tailwind warm bends). */
+  hueShift: z.number().min(0).max(3).optional(),
+  /** D8 — scales the whisper tint peak (0 = pure gray). */
+  neutralTint: z.number().min(0).max(4).optional(),
+  /** D8 — override the derived neutral hue (degrees). */
+  neutralHue: z.number().optional(),
+  /** D9/D12 — app-background lightness per mode (L*), or OLED black. */
+  background: z
+    .object({
+      light: z.number().min(90).max(100).optional(),
+      dark: z.union([z.number().min(0).max(20), z.literal("oled")]).optional(),
+    })
+    .optional(),
+  /** D2 — solve solids to the full WCAG 4.5 on-label bar. */
+  strictOnSolid: z.boolean().optional(),
+  /**
+   * D2 — guarantee policy: `relaxed` reports border-floor misses as warnings
+   * instead of failing the build (text guarantees never relax); `strict`
+   * implies `strictOnSolid`. Absent = `default`.
+   */
+  guaranteePolicy: z.enum(["relaxed", "default", "strict"]).optional(),
+  /**
+   * D2 — per-palette border placement targets: WCAG vs the app background,
+   * per border job, one value or per-mode values. Key `'*'` applies to every
+   * palette without its own entry. A target below the default floor is
+   * honored and priced as a report warning.
+   */
+  borders: z
+    .record(
+      z.string(),
+      z.object({
+        "400": borderTargetValue.optional(),
+        "500": borderTargetValue.optional(),
+        "600": borderTargetValue.optional(),
+      }),
+    )
+    .optional(),
+  /**
+   * D11 — the categorical series strategy: `tonal` (default) shades one brand
+   * hue, `vivid` / `muted` spread hues around the accent at high / low chroma.
+   */
+  chartPalette: z.enum(["tonal", "vivid", "muted"]).optional(),
+})
+
+export type ThemeOptions = z.infer<typeof themeOptionsSchema>

--- a/packages/colors/src/theme.ts
+++ b/packages/colors/src/theme.ts
@@ -37,156 +37,9 @@ import {
   type ScaleColors,
   transposeSkeleton,
 } from "./scale"
+import type { ThemeOptions } from "./schema"
 import { lstarOf, type Oklch, oklchCss, toOklch } from "./space"
 import { type GuaranteeResult, verifyLadder, verifyScale } from "./verify"
-
-/** WCAG ratio vs the app background (1.05–21), one value or per mode. */
-type BorderTargetValue = number | { light?: number; dark?: number }
-
-export interface ThemeOptions {
-  /** Parsable CSS colors; extra keys are custom palettes. */
-  seeds: {
-    accent: string
-    neutral?: string
-    success?: string
-    warning?: string
-    danger?: string
-    info?: string
-    [palette: string]: string | undefined
-  }
-  /** D7 — pin the accent verbatim at the solid step; the report prices it. */
-  preserveSeed?: boolean
-  /** D5 — scales the fitted chroma curve, 0–2 (1 ≈ Radix, ~1.33 ≈ Tailwind). */
-  vividness?: number
-  /** D6 — scalar on the hue-band bend table, 0–3 (1.6 ≈ Tailwind warm bends). */
-  hueShift?: number
-  /** D8 — scales the whisper tint peak, 0–4 (0 = pure gray). */
-  neutralTint?: number
-  /** D8 — override the derived neutral hue (degrees). */
-  neutralHue?: number
-  /** D9/D12 — app-background lightness per mode (L*: light 90–100, dark 0–20), or OLED black. */
-  background?: { light?: number; dark?: number | "oled" }
-  /** D2 — solve solids to the full WCAG 4.5 on-label bar. */
-  strictOnSolid?: boolean
-  /**
-   * D2 — guarantee policy: `relaxed` reports border-floor misses as warnings
-   * instead of failing the build (text guarantees never relax); `strict`
-   * implies `strictOnSolid`. Absent = `default`.
-   */
-  guaranteePolicy?: "relaxed" | "default" | "strict"
-  /**
-   * D2 — per-palette border placement targets: WCAG vs the app background,
-   * per border job, one value or per-mode values. Key `'*'` applies to every
-   * palette without its own entry. A target below the default floor is
-   * honored and priced as a report warning.
-   */
-  borders?: Record<
-    string,
-    {
-      "400"?: BorderTargetValue
-      "500"?: BorderTargetValue
-      "600"?: BorderTargetValue
-    }
-  >
-  /**
-   * D11 — the categorical series strategy: `tonal` (default) shades one brand
-   * hue, `vivid` / `muted` spread hues around the accent at high / low chroma.
-   */
-  chartPalette?: "tonal" | "vivid" | "muted"
-}
-
-/* The input gate: a clear error at the boundary beats a deep engine throw. */
-
-class ThemeOptionsError extends Error {
-  constructor(path: string, message: string) {
-    super(`createTheme: ${path} ${message}`)
-    this.name = "ThemeOptionsError"
-  }
-}
-
-function checkColor(path: string, value: unknown): void {
-  if (value === undefined) return
-  try {
-    if (typeof value !== "string") throw new Error()
-    toOklch(value)
-  } catch {
-    throw new ThemeOptionsError(path, "is not a parsable CSS color")
-  }
-}
-
-function checkNumber(
-  path: string,
-  value: unknown,
-  min = -Infinity,
-  max = Infinity,
-): void {
-  if (value === undefined) return
-  if (typeof value !== "number" || !Number.isFinite(value))
-    throw new ThemeOptionsError(path, "must be a number")
-  if (value < min || value > max)
-    throw new ThemeOptionsError(path, `must be between ${min} and ${max}`)
-}
-
-function checkBoolean(path: string, value: unknown): void {
-  if (value !== undefined && typeof value !== "boolean")
-    throw new ThemeOptionsError(path, "must be a boolean")
-}
-
-function checkEnum(path: string, value: unknown, values: string[]): void {
-  if (value !== undefined && !values.includes(value as string))
-    throw new ThemeOptionsError(path, `must be one of ${values.join(", ")}`)
-}
-
-function checkBorderTarget(path: string, value: unknown): void {
-  if (value === undefined) return
-  if (typeof value === "number") return checkNumber(path, value, 1.05, 21)
-  if (typeof value !== "object" || value === null)
-    throw new ThemeOptionsError(path, "must be a ratio or a per-mode pair")
-  const pair = value as { light?: unknown; dark?: unknown }
-  checkNumber(`${path}.light`, pair.light, 1.05, 21)
-  checkNumber(`${path}.dark`, pair.dark, 1.05, 21)
-}
-
-function validateThemeOptions(input: ThemeOptions): ThemeOptions {
-  if (typeof input !== "object" || input === null)
-    throw new ThemeOptionsError("options", "must be an object")
-  if (typeof input.seeds !== "object" || input.seeds === null)
-    throw new ThemeOptionsError("seeds", "must be an object")
-  if (input.seeds.accent === undefined)
-    throw new ThemeOptionsError("seeds.accent", "is required")
-  for (const [name, seed] of Object.entries(input.seeds))
-    checkColor(`seeds.${name}`, seed)
-  checkBoolean("preserveSeed", input.preserveSeed)
-  checkNumber("vividness", input.vividness, 0, 2)
-  checkNumber("hueShift", input.hueShift, 0, 3)
-  checkNumber("neutralTint", input.neutralTint, 0, 4)
-  checkNumber("neutralHue", input.neutralHue)
-  if (input.background !== undefined) {
-    if (typeof input.background !== "object" || input.background === null)
-      throw new ThemeOptionsError("background", "must be an object")
-    checkNumber("background.light", input.background.light, 90, 100)
-    if (input.background.dark !== "oled")
-      checkNumber("background.dark", input.background.dark, 0, 20)
-  }
-  checkBoolean("strictOnSolid", input.strictOnSolid)
-  checkEnum("guaranteePolicy", input.guaranteePolicy, [
-    "relaxed",
-    "default",
-    "strict",
-  ])
-  if (input.borders !== undefined) {
-    if (typeof input.borders !== "object" || input.borders === null)
-      throw new ThemeOptionsError("borders", "must be an object")
-    for (const [palette, spec] of Object.entries(input.borders)) {
-      if (typeof spec !== "object" || spec === null)
-        throw new ThemeOptionsError(`borders.${palette}`, "must be an object")
-      for (const job of ["400", "500", "600"] as const)
-        checkBorderTarget(`borders.${palette}.${job}`, spec[job])
-    }
-  }
-  checkEnum("chartPalette", input.chartPalette, ["tonal", "vivid", "muted"])
-  return input
-}
 
 export interface ModeOutput {
   /** The app background (= neutral step 25). */
@@ -221,9 +74,8 @@ export interface Theme {
 const CORE_ORDER = ["neutral", "accent", "success", "warning", "danger", "info"]
 
 export function createTheme(input: string | ThemeOptions): Theme {
-  const options = validateThemeOptions(
-    typeof input === "string" ? { seeds: { accent: input } } : input,
-  )
+  const options: ThemeOptions =
+    typeof input === "string" ? { seeds: { accent: input } } : input
 
   const vividness = options.vividness ?? 1
   const hueShift = options.hueShift ?? 1

--- a/packages/colors/src/theme.ts
+++ b/packages/colors/src/theme.ts
@@ -3,8 +3,6 @@
  * modes × {accent, neutral, status} × 12 steps + on-* + chart palettes, all guarantees enforced in-loop and audited in the report.
  */
 
-import { z } from "zod"
-
 import {
   CATEGORICAL_CHROMA,
   categoricalPalettes,
@@ -42,87 +40,153 @@ import {
 import { lstarOf, type Oklch, oklchCss, toOklch } from "./space"
 import { type GuaranteeResult, verifyLadder, verifyScale } from "./verify"
 
-const colorString = z.string().refine(
-  (value) => {
-    try {
-      toOklch(value)
-      return true
-    } catch {
-      return false
-    }
-  },
-  { message: "not a parsable CSS color" },
-)
+/** WCAG ratio vs the app background (1.05–21), one value or per mode. */
+type BorderTargetValue = number | { light?: number; dark?: number }
 
-const borderTargetRatio = z.number().min(1.05).max(21)
-const borderTargetValue = z.union([
-  borderTargetRatio,
-  z.object({
-    light: borderTargetRatio.optional(),
-    dark: borderTargetRatio.optional(),
-  }),
-])
-
-export const themeOptionsSchema = z.object({
-  seeds: z
-    .object({
-      accent: colorString,
-      neutral: colorString.optional(),
-      success: colorString.optional(),
-      warning: colorString.optional(),
-      danger: colorString.optional(),
-      info: colorString.optional(),
-    })
-    .catchall(colorString),
+export interface ThemeOptions {
+  /** Parsable CSS colors; extra keys are custom palettes. */
+  seeds: {
+    accent: string
+    neutral?: string
+    success?: string
+    warning?: string
+    danger?: string
+    info?: string
+    [palette: string]: string | undefined
+  }
   /** D7 — pin the accent verbatim at the solid step; the report prices it. */
-  preserveSeed: z.boolean().optional(),
-  /** D5 — scales the fitted chroma curve (1 ≈ Radix, ~1.33 ≈ Tailwind). */
-  vividness: z.number().min(0).max(2).optional(),
-  /** D6 — scalar on the hue-band bend table (1.6 ≈ Tailwind warm bends). */
-  hueShift: z.number().min(0).max(3).optional(),
-  /** D8 — scales the whisper tint peak (0 = pure gray). */
-  neutralTint: z.number().min(0).max(4).optional(),
+  preserveSeed?: boolean
+  /** D5 — scales the fitted chroma curve, 0–2 (1 ≈ Radix, ~1.33 ≈ Tailwind). */
+  vividness?: number
+  /** D6 — scalar on the hue-band bend table, 0–3 (1.6 ≈ Tailwind warm bends). */
+  hueShift?: number
+  /** D8 — scales the whisper tint peak, 0–4 (0 = pure gray). */
+  neutralTint?: number
   /** D8 — override the derived neutral hue (degrees). */
-  neutralHue: z.number().optional(),
-  /** D9/D12 — app-background lightness per mode (L*), or OLED black. */
-  background: z
-    .object({
-      light: z.number().min(90).max(100).optional(),
-      dark: z.union([z.number().min(0).max(20), z.literal("oled")]).optional(),
-    })
-    .optional(),
+  neutralHue?: number
+  /** D9/D12 — app-background lightness per mode (L*: light 90–100, dark 0–20), or OLED black. */
+  background?: { light?: number; dark?: number | "oled" }
   /** D2 — solve solids to the full WCAG 4.5 on-label bar. */
-  strictOnSolid: z.boolean().optional(),
+  strictOnSolid?: boolean
   /**
    * D2 — guarantee policy: `relaxed` reports border-floor misses as warnings
    * instead of failing the build (text guarantees never relax); `strict`
    * implies `strictOnSolid`. Absent = `default`.
    */
-  guaranteePolicy: z.enum(["relaxed", "default", "strict"]).optional(),
+  guaranteePolicy?: "relaxed" | "default" | "strict"
   /**
    * D2 — per-palette border placement targets: WCAG vs the app background,
    * per border job, one value or per-mode values. Key `'*'` applies to every
    * palette without its own entry. A target below the default floor is
    * honored and priced as a report warning.
    */
-  borders: z
-    .record(
-      z.string(),
-      z.object({
-        "400": borderTargetValue.optional(),
-        "500": borderTargetValue.optional(),
-        "600": borderTargetValue.optional(),
-      }),
-    )
-    .optional(),
+  borders?: Record<
+    string,
+    {
+      "400"?: BorderTargetValue
+      "500"?: BorderTargetValue
+      "600"?: BorderTargetValue
+    }
+  >
   /**
    * D11 — the categorical series strategy: `tonal` (default) shades one brand
    * hue, `vivid` / `muted` spread hues around the accent at high / low chroma.
    */
-  chartPalette: z.enum(["tonal", "vivid", "muted"]).optional(),
-})
+  chartPalette?: "tonal" | "vivid" | "muted"
+}
 
-export type ThemeOptions = z.infer<typeof themeOptionsSchema>
+/* The input gate: a clear error at the boundary beats a deep engine throw. */
+
+class ThemeOptionsError extends Error {
+  constructor(path: string, message: string) {
+    super(`createTheme: ${path} ${message}`)
+    this.name = "ThemeOptionsError"
+  }
+}
+
+function checkColor(path: string, value: unknown): void {
+  if (value === undefined) return
+  try {
+    if (typeof value !== "string") throw new Error()
+    toOklch(value)
+  } catch {
+    throw new ThemeOptionsError(path, "is not a parsable CSS color")
+  }
+}
+
+function checkNumber(
+  path: string,
+  value: unknown,
+  min = -Infinity,
+  max = Infinity,
+): void {
+  if (value === undefined) return
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new ThemeOptionsError(path, "must be a number")
+  if (value < min || value > max)
+    throw new ThemeOptionsError(path, `must be between ${min} and ${max}`)
+}
+
+function checkBoolean(path: string, value: unknown): void {
+  if (value !== undefined && typeof value !== "boolean")
+    throw new ThemeOptionsError(path, "must be a boolean")
+}
+
+function checkEnum(path: string, value: unknown, values: string[]): void {
+  if (value !== undefined && !values.includes(value as string))
+    throw new ThemeOptionsError(path, `must be one of ${values.join(", ")}`)
+}
+
+function checkBorderTarget(path: string, value: unknown): void {
+  if (value === undefined) return
+  if (typeof value === "number") return checkNumber(path, value, 1.05, 21)
+  if (typeof value !== "object" || value === null)
+    throw new ThemeOptionsError(path, "must be a ratio or a per-mode pair")
+  const pair = value as { light?: unknown; dark?: unknown }
+  checkNumber(`${path}.light`, pair.light, 1.05, 21)
+  checkNumber(`${path}.dark`, pair.dark, 1.05, 21)
+}
+
+function validateThemeOptions(input: ThemeOptions): ThemeOptions {
+  if (typeof input !== "object" || input === null)
+    throw new ThemeOptionsError("options", "must be an object")
+  if (typeof input.seeds !== "object" || input.seeds === null)
+    throw new ThemeOptionsError("seeds", "must be an object")
+  if (input.seeds.accent === undefined)
+    throw new ThemeOptionsError("seeds.accent", "is required")
+  for (const [name, seed] of Object.entries(input.seeds))
+    checkColor(`seeds.${name}`, seed)
+  checkBoolean("preserveSeed", input.preserveSeed)
+  checkNumber("vividness", input.vividness, 0, 2)
+  checkNumber("hueShift", input.hueShift, 0, 3)
+  checkNumber("neutralTint", input.neutralTint, 0, 4)
+  checkNumber("neutralHue", input.neutralHue)
+  if (input.background !== undefined) {
+    if (typeof input.background !== "object" || input.background === null)
+      throw new ThemeOptionsError("background", "must be an object")
+    checkNumber("background.light", input.background.light, 90, 100)
+    if (input.background.dark !== "oled")
+      checkNumber("background.dark", input.background.dark, 0, 20)
+  }
+  checkBoolean("strictOnSolid", input.strictOnSolid)
+  checkEnum("guaranteePolicy", input.guaranteePolicy, [
+    "relaxed",
+    "default",
+    "strict",
+  ])
+  if (input.borders !== undefined) {
+    if (typeof input.borders !== "object" || input.borders === null)
+      throw new ThemeOptionsError("borders", "must be an object")
+    for (const [palette, spec] of Object.entries(input.borders)) {
+      if (typeof spec !== "object" || spec === null)
+        throw new ThemeOptionsError(`borders.${palette}`, "must be an object")
+      for (const job of ["400", "500", "600"] as const)
+        checkBorderTarget(`borders.${palette}.${job}`, spec[job])
+    }
+  }
+  checkEnum("chartPalette", input.chartPalette, ["tonal", "vivid", "muted"])
+  return input
+}
 
 export interface ModeOutput {
   /** The app background (= neutral step 25). */
@@ -157,10 +221,9 @@ export interface Theme {
 const CORE_ORDER = ["neutral", "accent", "success", "warning", "danger", "info"]
 
 export function createTheme(input: string | ThemeOptions): Theme {
-  const options =
-    typeof input === "string"
-      ? themeOptionsSchema.parse({ seeds: { accent: input } })
-      : themeOptionsSchema.parse(input)
+  const options = validateThemeOptions(
+    typeof input === "string" ? { seeds: { accent: input } } : input,
+  )
 
   const vividness = options.vividness ?? 1
   const hueShift = options.hueShift ?? 1
@@ -225,7 +288,7 @@ export function createTheme(input: string | ThemeOptions): Theme {
     )
   }
   for (const [name, value] of Object.entries(options.seeds)) {
-    if (name in seeds) continue
+    if (name in seeds || value === undefined) continue
     seeds[name] = classify(toOklch(value))
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       culori:
         specifier: ^4.0.2
         version: 4.0.2
+      zod:
+        specifier: ^4.2.1
+        version: 4.4.3
     devDependencies:
       '@adobe/leonardo-contrast-colors':
         specifier: ^1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       culori:
         specifier: ^4.0.2
         version: 4.0.2
-      zod:
-        specifier: ^4.2.1
-        version: 4.2.1
     devDependencies:
       '@adobe/leonardo-contrast-colors':
         specifier: ^1.1.0
@@ -489,11 +486,6 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -6542,9 +6534,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.2.1:
-    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -6621,8 +6610,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -6672,7 +6661,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -6718,13 +6707,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.7
-
   '@babel/parser@7.29.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -10469,7 +10454,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -12599,8 +12584,6 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
-
-  zod@4.2.1: {}
 
   zod@4.4.3: {}
 

--- a/www/scripts/registry-build.ts
+++ b/www/scripts/registry-build.ts
@@ -12,6 +12,9 @@ import path from "node:path"
 import { format } from "oxfmt"
 import { rimraf } from "rimraf"
 
+import { themeOptionsSchema } from "@dotui/colors/schema"
+
+import { PRESETS } from "../src/modules/presets/presets-data"
 import {
   buildPublishables,
   collectBaseFiles,
@@ -28,6 +31,7 @@ import {
   emitDarkOverridesCss,
   emitPrimitivesCss,
   resolveColorConfig,
+  themeOptionsFromConfig,
 } from "../src/registry/theme"
 import type { RegistryItem } from "../src/registry/types"
 
@@ -893,6 +897,26 @@ async function buildShadcnPublishables(
  * block that references them. This file is site-only — the shipped theme
  * flattens the semantic tokens to literals instead (see publisher/emit-theme).
  */
+// The engine's input contract is a zod schema checked here, at build time,
+// for the default and every built-in preset — `createTheme` itself trusts
+// its typed input so the client never ships zod.
+function checkColorConfigs() {
+  const configs = [
+    ["default", DEFAULT_COLOR_CONFIG] as const,
+    ...PRESETS.map((preset) => [preset.id, preset.designSystem.color] as const),
+  ]
+  for (const [name, config] of configs) {
+    if (!config) continue
+    const result = themeOptionsSchema.safeParse(themeOptionsFromConfig(config))
+    if (!result.success) {
+      throw new Error(
+        `Invalid color config for preset "${name}": ${result.error.message}`,
+      )
+    }
+  }
+  console.log(`  ✓ color configs (${configs.length} presets)`)
+}
+
 async function generateBaseColorsCss() {
   const primitives = emitPrimitivesCss(resolveColorConfig(DEFAULT_COLOR_CONFIG))
   const dark = emitDarkOverridesCss(DEFAULT_SEMANTICS)
@@ -909,6 +933,7 @@ async function main() {
 
   try {
     console.log("Generating base color css")
+    checkColorConfigs()
     await generateBaseColorsCss()
 
     // Fresh item lists globbed from disk — never the (possibly stale) committed

--- a/www/src/registry/theme/color-config.ts
+++ b/www/src/registry/theme/color-config.ts
@@ -6,8 +6,6 @@
  * no algorithm menu — the v1 `{algorithm, knobs}` shape migrates below.
  */
 
-import { z } from "zod"
-
 import { STATUS_SEEDS, toOklch } from "@dotui/colors"
 
 import type {
@@ -18,93 +16,65 @@ import type {
 } from "./types"
 import { JOB_STEPS, type JobName } from "./types"
 
-const JOB_NAMES = Object.keys(JOB_STEPS) as [JobName, ...JobName[]]
-const tokenTargetSpec = z.object({
-  palette: z.string().min(1),
-  job: z.enum(JOB_NAMES),
-})
-const tokenOverride = z.union([
-  tokenTargetSpec,
-  z.object({
-    light: tokenTargetSpec.optional(),
-    dark: tokenTargetSpec.optional(),
-  }),
-])
+/** WCAG ratio vs the app background (1.05–21), one value or per mode. */
+type BorderTarget = number | { light?: number; dark?: number }
 
-const borderTargetRatio = z.number().min(1.05).max(21)
-const borderTargetValue = z.union([
-  borderTargetRatio,
-  z.object({
-    light: borderTargetRatio.optional(),
-    dark: borderTargetRatio.optional(),
-  }),
-])
-const borderTargetsSchema = z.object({
-  "400": borderTargetValue.optional(),
-  "500": borderTargetValue.optional(),
-  "600": borderTargetValue.optional(),
-})
-
-export const colorConfigSchema = z.object({
-  v: z.literal(2),
-  seeds: z.object({
+export interface ColorConfig {
+  v: 2
+  seeds: {
     /** The brand accent — the one required input. */
-    accent: z.string(),
+    accent: string
     /** Absent → auto-tinted from the accent hue at whisper chroma (engine D8). */
-    neutral: z.string().optional(),
-    success: z.string().optional(),
-    warning: z.string().optional(),
-    danger: z.string().optional(),
-    info: z.string().optional(),
+    neutral?: string
+    success?: string
+    warning?: string
+    danger?: string
+    info?: string
     /** Splits selection controls + focus onto their own ramp (else = primary). */
-    selection: z.string().optional(),
-  }),
-  /** App-background lightness per mode (L*); dark accepts OLED black. */
-  background: z
-    .object({
-      light: z.number().min(90).max(100).optional(),
-      dark: z.union([z.number().min(0).max(20), z.literal("oled")]).optional(),
-    })
-    .optional(),
-  /** Scales the fitted chroma curve (1 ≈ Radix, ~1.33 ≈ Tailwind). */
-  vividness: z.number().min(0).max(2).optional(),
-  /** Scalar on the hue-band bend table (1.6 ≈ Tailwind warm bends). */
-  hueShift: z.number().min(0).max(3).optional(),
-  /** Scales the neutral whisper tint (0 = pure gray). */
-  neutralTint: z.number().min(0).max(4).optional(),
+    selection?: string
+  }
+  /** App-background lightness per mode (L*: light 90–100, dark 0–20); dark accepts OLED black. */
+  background?: { light?: number; dark?: number | "oled" }
+  /** Scales the fitted chroma curve, 0–2 (1 ≈ Radix, ~1.33 ≈ Tailwind). */
+  vividness?: number
+  /** Scalar on the hue-band bend table, 0–3 (1.6 ≈ Tailwind warm bends). */
+  hueShift?: number
+  /** Scales the neutral whisper tint, 0–4 (0 = pure gray). */
+  neutralTint?: number
   /** OKLCH hue the neutral tint leans toward (absent = follow the accent). */
-  neutralHue: z.number().min(0).max(360).optional(),
+  neutralHue?: number
   /** Pin the accent verbatim at the solid step; the report prices it. */
-  preserveSeed: z.boolean().optional(),
+  preserveSeed?: boolean
   /**
    * Guarantee policy (engine D2): `relaxed` prices border-floor misses as
    * warnings; `strict` solves solid labels to the full WCAG 4.5. Stored only
    * when non-default — absent means the default policy.
    */
-  guaranteePolicy: z.enum(["relaxed", "strict"]).optional(),
+  guaranteePolicy?: "relaxed" | "strict"
   /**
    * Border placement targets (engine D2): WCAG vs the app background per
    * border job, one value or per-mode values, keyed by palette (`'*'` = all).
    */
-  borders: z.record(z.string(), borderTargetsSchema).optional(),
+  borders?: Record<
+    string,
+    { "400"?: BorderTarget; "500"?: BorderTarget; "600"?: BorderTarget }
+  >
   /**
    * Ramp the primary-action tokens draw from. Stored only as `'accent'`
    * (brand-colored primary); absent means the default neutral (black/white).
    */
-  primary: z.literal("accent").optional(),
+  primary?: "accent"
   /**
    * Per-token remaps (T5): token name → (palette, job), one destination or a
    * per-mode pair. Applied by the semantic resolver; unknown names are inert.
    */
-  overrides: z.record(z.string(), tokenOverride).optional(),
+  overrides?: TokenOverrides
   /**
    * Categorical chart series (engine D11): absent = tonal shades of the accent
    * (shadcn parity); `vivid` / `muted` spread hues around it.
    */
-  chartPalette: z.enum(["vivid", "muted"]).optional(),
-})
-
-export type ColorConfig = z.infer<typeof colorConfigSchema>
+  chartPalette?: "vivid" | "muted"
+}
 export type PaletteSeeds = ColorConfig["seeds"]
 
 /**
@@ -225,6 +195,7 @@ function salvageBorders(raw: unknown): ColorConfig["borders"] {
  * nearest v2 axes (algorithm + per-producer knobs are gone; the one engine
  * covers their range). Unknown shapes fall back to the default, and every
  * kept seed is verified parseable — never a decode or render explosion.
+ * Also the validator in front of the engine (`resolveColorConfig`).
  */
 export function migrateColorConfig(input: unknown): ColorConfig {
   if (typeof input !== "object" || input === null) return DEFAULT_COLOR_CONFIG

--- a/www/src/registry/theme/index.ts
+++ b/www/src/registry/theme/index.ts
@@ -37,7 +37,6 @@ export {
 } from "./emit-css"
 export {
   type ColorConfig,
-  colorConfigSchema,
   DEFAULT_COLOR_CONFIG,
   DEFAULT_STATUS_SEEDS,
   migrateColorConfig,

--- a/www/src/registry/theme/primitives.ts
+++ b/www/src/registry/theme/primitives.ts
@@ -15,7 +15,7 @@ import {
   type ThemeOptions,
 } from "@dotui/colors"
 
-import { type ColorConfig, colorConfigSchema } from "./color-config"
+import { type ColorConfig, migrateColorConfig } from "./color-config"
 import { PALETTE_ORDER } from "./palettes"
 
 export type Ramp = Record<string, string>
@@ -53,13 +53,12 @@ export function themeOptionsFromConfig(config: ColorConfig): ThemeOptions {
 }
 
 /**
- * Resolve a config through the engine. Validates first — this also runs in
- * the publisher path on decoded request data, where a clear error beats a
+ * Resolve a config through the engine. Salvages first — this also runs in
+ * the publisher path on decoded request data, where a clamped axis beats a
  * deep engine throw.
  */
 export function resolveColorConfig(config: ColorConfig): Theme {
-  const parsed = colorConfigSchema.parse(config)
-  return createTheme(themeOptionsFromConfig(parsed))
+  return createTheme(themeOptionsFromConfig(migrateColorConfig(config)))
 }
 
 export interface EmitPrimitivesOptions {


### PR DESCRIPTION
## Problem

Zod shipped on every page in the shared `styles` chunk (the one `DesignSystemProvider` / `createStyles` live in), twice: `www/src/registry/theme/color-config.ts` built a runtime `ColorConfig` schema, and `@dotui/colors` validated `createTheme` options with its own copy of zod 4. Together 132 KB raw / ~35 KB gz on the critical path, for two `.parse()` calls on input that had already been sanitized upstream.

## Changes

- `registry/theme/color-config.ts` — `ColorConfig` is a hand-written interface (same fields and doc comments, ranges stated in the comments). `colorConfigSchema` is gone; `migrateColorConfig`, which already salvaged v2 configs field by field, is the runtime gate.
- `registry/theme/primitives.ts` — `resolveColorConfig` runs `migrateColorConfig` instead of `colorConfigSchema.parse`: out-of-range axes clamp and bad seeds fall back rather than throwing.
- `packages/colors` — the zod `themeOptionsSchema` moves to `src/schema.ts`, exported as `@dotui/colors/schema`. `ThemeOptions` is still inferred from it (type-only, erased in the client), so the type and the contract can't drift. `createTheme` trusts its typed input instead of parsing. zod stays a dependency of the package; no client chunk imports it.
- `www/scripts/registry-build.ts` — the schema becomes a build-time gate: the default config and every built-in preset's engine options are validated through it, and the registry build fails on a violation (`✓ color configs (11 presets)`).

## Result

Local production build (Vite 8 / rolldown). First-load JS = entry script + every `modulepreload` + their transitive static imports, gzip level 9. (The HTML preload list alone undercounts — Chrome fetches a preloaded module's whole static graph; earlier audits used the shorter number.)

| page | before | after | Δ |
|---|---|---|---|
| entry chunk | 99.2 KB | 99.2 KB | 0 (zod was never in the entry itself) |
| `/` | 678.0 KB | 643.4 KB | **−34.7 KB (−5.1%)** |
| `/docs/components/button` | 856.1 KB | 821.4 KB | **−34.6 KB (−4.0%)** |
| `/studio` | 677.7 KB | 643.1 KB | **−34.6 KB (−5.1%)** |

The shared `styles` chunk goes 68.0 → 33.0 KB gz. `grep -l ZodError` over every client chunk matches only the react-hook-form docs demo chunk (route-scoped).

## Verification

- `pnpm check`, `pnpm typecheck`, `pnpm test` (394 tests, including the engine's full-schema-range and slider-extremes cases).
- `pnpm smoke:examples --example origin-tanstack-start` — regenerated output is byte-identical (no `examples/` diff).
- Browser, dev server on this branch: `/studio` — changed vividness to 1.6, the URL gained `?preset=…`, reload restores 1.6 in the Color chapter, no console errors; `/` renders the preset showcase scopes; `/docs/components/button` renders (59 icons); `/r/init?preset=<spotify>` differs from the default on 64 light-mode vars, `?preset=garbage` returns 200 with the defaults.

## Notes from the same audit (no PR)

Measured with the same method on `main`, for #395:

- **Icon barrel (`@/registry/__generated__/icons`, 18 KB gz)**: splitting it into one module per icon (plus a rolldown `moduleSideEffects` rule, which is required — rolldown only prunes a barrel's unused re-exports when the target module is provably side-effect free, and `createIcon` modules aren't) removes the bytes from the HTML preload list but not from the first-load graph: the landing showcase uses 66 of the 182 icons, and the split spreads them over 48 chunks — landing 678 → 680 KB gz with +65 requests. Not opened.
- **culori + `@dotui/colors` (~61 KB raw) and the font catalog (3.5 KB gz)** are load-bearing on the landing: the hero cards resolve preset color configs through `DesignSystemProvider`, and the preset resolver calls `fontStack`. They reach docs pages too, because every registry `styles.ts` imports `createStyles` from `@/lib/styles`, the module that also hosts the provider and its engine imports. The lever is lazy-loading the engine inside the provider (only when `color` is set), which touches SSR/hydration of the scoped `<style>` hoistables — its own PR.
- **react-aria locales**: ~49 KB gz on `/`, 45 KB on a docs page, 24 KB on `/studio` — commented on #420 (product call).
- **pako**: 16 KB gz on every docs component page and `/studio` (not the landing) — commented on #421.
