### PR TITLE
fix(docs): keep component cards visible while the preview preset resolves

### DIFF
--- a/www/src/modules/docs/components-list/component-card.tsx
+++ b/www/src/modules/docs/components-list/component-card.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useRef, useState } from "react"
 import { Link } from "@tanstack/react-router"
 
+import { cn } from "@/registry/lib/utils"
+
+import { previewPendingClass } from "../preview-controls"
 import { componentDemos } from "./demos"
 
 interface ComponentCardProps {
@@ -73,7 +76,7 @@ export function ComponentCard({
             of the tab order and lets clicks fall through to the card link, so the
             whole card navigates instead of an embedded demo hijacking the click. */}
         {fill ? (
-          <div inert className="absolute inset-0">
+          <div inert className={cn("absolute inset-0", previewPendingClass)}>
             {content}
           </div>
         ) : (
@@ -82,14 +85,23 @@ export function ComponentCard({
             className="absolute inset-4 flex items-center justify-center overflow-hidden"
           >
             {stretch ? (
-              <div inert className="flex w-full items-center justify-center">
+              <div
+                inert
+                className={cn(
+                  "flex w-full items-center justify-center",
+                  previewPendingClass,
+                )}
+              >
                 {content}
               </div>
             ) : (
               <div
                 ref={demoRef}
                 inert
-                className="flex items-center justify-center"
+                className={cn(
+                  "flex items-center justify-center",
+                  previewPendingClass,
+                )}
                 style={{ transform: `scale(${Math.min(scale, fit)})` }}
               >
                 {content}

--- a/www/src/modules/docs/components-list/components-grid.tsx
+++ b/www/src/modules/docs/components-list/components-grid.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { DemoPreset } from "../demo-preset"
-import { PreviewVeil } from "../preview-controls"
+import { usePreviewPending } from "../preview-controls"
 import { ComponentCard } from "./component-card"
 import { componentsData } from "./components-data"
 
@@ -11,6 +11,10 @@ import { componentsData } from "./components-data"
  * feeds the page's table of contents like any other docs heading.
  */
 export function ComponentsGrid({ category }: { category: string }) {
+  // No veil over the grid: the cards stay in place while the stored preset
+  // resolves and only the demo inside each card waits (see component-card.tsx).
+  // The flag still has to be cleared, which this hook does.
+  usePreviewPending()
   const data = componentsData.find((c) => c.slug === category)
 
   if (!data) {
@@ -24,8 +28,7 @@ export function ComponentsGrid({ category }: { category: string }) {
 
   return (
     <DemoPreset>
-      <div className="relative mt-6 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-3">
-        <PreviewVeil />
+      <div className="mt-6 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-3">
         {data.components.map((component) => (
           <ComponentCard
             key={component.slug}

--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -47,21 +47,36 @@ const modeStore = createPersistedStore<PreviewMode | null>(
 )
 
 /**
- * Covers a preview until hydration applies the stored preset/mode. Rendered on
- * every load but only visible (via CSS) when the pre-paint script flagged a
- * stored selection (see preview-pending.ts), so first-time visitors keep the
- * instant SSR previews. Drop inside any `relative` preview container that
- * isn't wrapped in PreviewPanel.
+ * Whether the SSR'd previews still show the wrong preset/mode — true only when
+ * the pre-paint script flagged a stored selection (see preview-pending.ts), so
+ * first-time visitors keep the instant SSR previews. Clears the flag once the
+ * re-render with the stored selection commits, so nothing flashes the wrong
+ * preset and later navigations never wait.
  */
-export function PreviewVeil() {
+export function usePreviewPending() {
   const hydrated = useHydrated()
-  // Runs after the re-render with the stored selection commits, so the flag
-  // clears without a wrong-preset flash and later navigations never veil.
   useEffect(() => {
     if (hydrated)
       document.documentElement.removeAttribute("data-preview-pending")
   }, [hydrated])
-  if (hydrated) return null
+  return !hydrated
+}
+
+/**
+ * Hides pending preview content in place, for previews whose frame should stay
+ * visible while the preset resolves (the component cards). The container must
+ * call usePreviewPending() to clear the flag.
+ */
+export const previewPendingClass =
+  "transition-opacity duration-200 [[data-preview-pending]_&]:opacity-0"
+
+/**
+ * Covers a preview until hydration applies the stored preset/mode. Rendered on
+ * every load but only visible (via CSS) while pending. Drop inside any
+ * `relative` preview container that isn't wrapped in PreviewPanel.
+ */
+export function PreviewVeil() {
+  if (!usePreviewPending()) return null
   return (
     <div
       aria-hidden


### PR DESCRIPTION
## Summary

- On `/docs/components`, a stored preview preset (or mode) makes the pre-paint script flag the page as pending, and `PreviewVeil` covered each whole category grid with a `bg-bg` panel and one spinner — so the page opened as a tall empty area with a lone loader until hydration applied the preset.
- The grid no longer veils. The cards render right away, and only the demo inside each card is held back (`opacity-0` while `[data-preview-pending]`), fading in over 200ms once the preset resolves.
- `PreviewVeil`'s hydration/flag-clearing logic moved into `usePreviewPending()`, which the veil and the grid share; the grid calls it so the flag still clears.

Nothing is code-split or lazily mounted: the demos are still server-rendered and mount exactly as before, they are just invisible for the pending window.

## Verified

Dev server with a stored preset and client JS delayed 1.5s, sampled during the pending window:

| | before | after |
|---|---|---|
| grid veils covering the cards | 12 | 0 |
| cards on screen (72, all 192px) | hidden behind the veil | visible, bordered |
| demo opacity while pending | 1 (under the veil) | 0 |
| demo opacity once settled | 1 | 1 |

Screenshots of both pending states are in the PR thread.
