### PR TITLE
perf(docs): cut 196 KB of first-load JS on docs pages

### DIFF
--- a/www/content/docs/(root)/charts.mdx
+++ b/www/content/docs/(root)/charts.mdx
@@ -5,6 +5,8 @@ full: true
 preview: true
 ---
 
+import { ChartFamilyGrid } from "@/modules/charts/chart-family-grid"
+
 ## Bar charts
 
 <ChartFamilyGrid family="chart-bar" />

--- a/www/content/docs/(root)/components.mdx
+++ b/www/content/docs/(root)/components.mdx
@@ -5,6 +5,8 @@ full: true
 preview: true
 ---
 
+import { ComponentsGrid } from "@/modules/docs/components-list/components-grid"
+
 ## Buttons
 
 <ComponentsGrid category="buttons" />

--- a/www/scripts/perf-budget.json
+++ b/www/scripts/perf-budget.json
@@ -4,7 +4,7 @@
   "exclude": ["/internal/**"],
   "rules": [
     { "match": "/", "firstLoadGzKB": 645, "preloads": 40 },
-    { "match": "/docs/**", "firstLoadGzKB": 730, "preloads": 32 },
+    { "match": "/docs/**", "firstLoadGzKB": 535, "preloads": 32 },
     { "match": "/studio", "firstLoadGzKB": 585, "preloads": 75 }
   ],
   "default": { "firstLoadGzKB": 250, "preloads": 16 }

--- a/www/src/modules/charts/data.ts
+++ b/www/src/modules/charts/data.ts
@@ -1,14 +1,33 @@
-import { DemosIndex } from "@/registry/__generated__/demos"
+import { lazy, type ComponentType, type LazyExoticComponent } from "react"
 
 /**
- * Data layer for the `/docs/charts` showcase. Live demo components come
- * from the generated `DemosIndex` (lazy). The "Show code" modal additionally
+ * Data layer for the `/docs/charts` showcase. Live demo components are globbed
+ * straight from the chart families (lazy). The "Show code" modal additionally
  * pulls each variant's raw source on demand (see below).
  */
 
+// Chart demos only. The generated `DemosIndex` covers the whole registry, and
+// importing it here put that barrel — every demo's import thunk plus its
+// preload map — on the static path of every docs page.
+const demoModules = import.meta.glob(
+  "../../registry/ui/chart-*/demos/*.tsx",
+) as Record<string, () => Promise<{ default: ComponentType<object> }>>
+
+/** Demo key for a glob path: `.../ui/chart-bar/demos/multiple.tsx` → `chart-bar/demos/multiple`. */
+const keyOf = (path: string) =>
+  path.slice(path.indexOf("/ui/") + 4, -".tsx".length)
+
+const demoComponents = new Map<
+  string,
+  LazyExoticComponent<ComponentType<object>>
+>()
+for (const [path, load] of Object.entries(demoModules)) {
+  demoComponents.set(keyOf(path), lazy(load))
+}
+
 /** Lazy demo component for a demo key, or `undefined` if it doesn't exist. */
 export function getDemoComponent(key: string) {
-  return DemosIndex[key]?.component
+  return demoComponents.get(key)
 }
 
 /** Package managers offered in the install section, in display order. */
@@ -128,7 +147,7 @@ export function variantsFor(
   familyId: string,
 ): { key: string; label: string }[] {
   const prefix = `${familyId}/demos/`
-  return Object.keys(DemosIndex)
+  return [...demoComponents.keys()]
     .filter((key) => key.startsWith(prefix))
     .map((key) => ({
       key,

--- a/www/src/modules/docs/mdx-components.tsx
+++ b/www/src/modules/docs/mdx-components.tsx
@@ -1,10 +1,10 @@
+import { lazy, Suspense } from "react"
 import { ArrowUpRightIcon } from "lucide-react"
 import type { MDXComponents } from "mdx/types"
 
 import { cn } from "@/registry/lib/utils"
 import { Alert, type AlertProps } from "@/registry/ui/alert"
 import { Link } from "@/registry/ui/link"
-import { ChartFamilyGrid } from "@/modules/charts/chart-family-grid"
 import { CodeBlock, Pre } from "@/modules/docs/code-block"
 import {
   CodeBlockTab,
@@ -12,7 +12,6 @@ import {
   CodeBlockTabsList,
   CodeBlockTabsTrigger,
 } from "@/modules/docs/code-block-tabs"
-import { ComponentsGrid } from "@/modules/docs/components-list/components-grid"
 import {
   Demo,
   DemoCode,
@@ -23,6 +22,19 @@ import { Example } from "@/modules/docs/example"
 import { Examples, type ExamplesProps } from "@/modules/docs/examples"
 import { InteractiveDemo } from "@/modules/docs/interactive-demo"
 import { Reference, type ReferenceProps } from "@/modules/docs/reference"
+
+// The gallery grids render every preview in a category — and so pull the whole
+// demo set and its registry components behind them. Two pages use them; loading
+// them lazily keeps that weight off every other docs page's first load. SSR
+// streams the resolved grid into the prerendered HTML, so first paint is
+// unchanged and only a client-side navigation waits on the chunk.
+const ComponentsGrid = lazy(async () => ({
+  default: (await import("@/modules/docs/components-list/components-grid"))
+    .ComponentsGrid,
+}))
+const ChartFamilyGrid = lazy(async () => ({
+  default: (await import("@/modules/charts/chart-family-grid")).ChartFamilyGrid,
+}))
 
 export const mdxComponents: MDXComponents = {
   h1: ({ className, ...props }) => (
@@ -209,6 +221,14 @@ export const mdxComponents: MDXComponents = {
   Reference: ({ className, ...props }: ReferenceProps) => (
     <Reference className={cn("mt-4", className)} {...props} />
   ),
-  ComponentsGrid,
-  ChartFamilyGrid,
+  ComponentsGrid: (props: { category: string }) => (
+    <Suspense>
+      <ComponentsGrid {...props} />
+    </Suspense>
+  ),
+  ChartFamilyGrid: (props: { family: string }) => (
+    <Suspense>
+      <ChartFamilyGrid {...props} />
+    </Suspense>
+  ),
 }

--- a/www/src/modules/docs/mdx-components.tsx
+++ b/www/src/modules/docs/mdx-components.tsx
@@ -1,4 +1,3 @@
-import { lazy, Suspense } from "react"
 import { ArrowUpRightIcon } from "lucide-react"
 import type { MDXComponents } from "mdx/types"
 
@@ -22,19 +21,6 @@ import { Example } from "@/modules/docs/example"
 import { Examples, type ExamplesProps } from "@/modules/docs/examples"
 import { InteractiveDemo } from "@/modules/docs/interactive-demo"
 import { Reference, type ReferenceProps } from "@/modules/docs/reference"
-
-// The gallery grids render every preview in a category — and so pull the whole
-// demo set and its registry components behind them. Two pages use them; loading
-// them lazily keeps that weight off every other docs page's first load. SSR
-// streams the resolved grid into the prerendered HTML, so first paint is
-// unchanged and only a client-side navigation waits on the chunk.
-const ComponentsGrid = lazy(async () => ({
-  default: (await import("@/modules/docs/components-list/components-grid"))
-    .ComponentsGrid,
-}))
-const ChartFamilyGrid = lazy(async () => ({
-  default: (await import("@/modules/charts/chart-family-grid")).ChartFamilyGrid,
-}))
 
 export const mdxComponents: MDXComponents = {
   h1: ({ className, ...props }) => (
@@ -221,14 +207,8 @@ export const mdxComponents: MDXComponents = {
   Reference: ({ className, ...props }: ReferenceProps) => (
     <Reference className={cn("mt-4", className)} {...props} />
   ),
-  ComponentsGrid: (props: { category: string }) => (
-    <Suspense>
-      <ComponentsGrid {...props} />
-    </Suspense>
-  ),
-  ChartFamilyGrid: (props: { family: string }) => (
-    <Suspense>
-      <ChartFamilyGrid {...props} />
-    </Suspense>
-  ),
+  // The gallery grids (<ComponentsGrid>, <ChartFamilyGrid>) are imported by the
+  // two pages that use them, not registered here: they pull every preview demo
+  // and its registry component behind them, and this map is on every docs
+  // page's static import path.
 }


### PR DESCRIPTION
`#729` ratified the docs pages' weight; this cuts it. **/docs/** first-load JS: 715.4 → 518.5 KB gz (−196.9, −28%), 256 → 201 chunks.**

## What was on the docs client path

The perf-budget closure walk over a production build of `main`, per chunk:

| chunk | gz | why it was static |
| --- | --- | --- |
| `demos-*.js` | 36.3 KB (290 KB raw) | the generated `DemosIndex` — every registry demo's `React.lazy` thunk plus rolldown's preload map for all of them |
| `-docs-page-*.js` | 49.8 KB | the docs route chunk, with all 71 gallery demos inlined |
| `table`, `Calendar`, `Color`, `Tree`, `Virtualizer`, `questionnaire`, `token-field`, `otp-field`, `useDateFormatter`, … | ~120 KB combined | registry components reachable only through those gallery demos |

Both traced back to `mdxComponents`, which every docs page loads: it statically imports `ComponentsGrid` and `ChartFamilyGrid`, and `ChartFamilyGrid` → `modules/charts/data.ts` → the full `DemosIndex`. Two pages (`/docs/components`, `/docs/charts`) use those grids; the other 82 paid for them.

(Shiki is not on the client path — `#723` already moved runtime highlighting to sugar-high. The remaining `highlight-*.js` is 4.7 KB.)

## Changes, measured independently

**1. Scope the chart demo index to charts** — `modules/charts/data.ts` used `DemosIndex` only to enumerate a family's variants and resolve one component. A chart-scoped `import.meta.glob` (the pattern already used a few lines below for raw sources) does both without the registry-wide barrel.

> 715.4 → 680.2 KB gz · **−35.2 KB**

**2. Move the two gallery grids out of `mdxComponents`** — `ComponentsGrid` and `ChartFamilyGrid` are now imported by `components.mdx` and `charts.mdx` themselves. MDX pages are already dynamically imported and awaited before render, so each grid lands in its own page's chunk — off every other page, and still a plain static import where it is used.

> 680.2 → 518.5 KB gz · **−161.7 KB**

## Budget

`/docs/**` lowered **730 → 535** (~15 KB over the new measured 518.5), so the row stops authorising the old weight. Other rows re-checked and unchanged — all moved in the right direction: entry chunk 97.2 → 96.8, `/` 628.9 → 628.2, `/studio` 569.9 → 569.2. `/studio` preloads went 69 → 70 (cap 75).

```
                          before        after
entry chunk               97.2          96.8   / 100 KB gz
/                        628.9         628.2   / 645 KB gz
/docs/**                 715.5         518.5   / 535 KB gz   (was / 730)
/studio                  570.0         569.2   / 585 KB gz
```

## No layout shift, no SSR regression

The first cut of change 2 used `React.lazy` + `Suspense`. That held the bytes but gave the two gallery pages an empty fallback on client-side navigation — the grid collapsed and popped in. Importing from the MDX page instead removes the boundary entirely: the page's own chunk already has to resolve before it renders, so the grid is there on first paint of that page.

Measured against the built server, clicking through to each gallery page:

- `/docs/components` — **CLS 0**, 72 cards appearing in a single step at the final height; no intermediate empty state.
- `/docs/charts` — **CLS 0**, height constant across the transition.
- `/docs/components/button` — 206 JS chunks, zero gallery chunks among them.
- No console errors on any of them.

Prerendered HTML is unchanged: 72 cards with real demo markup (the Table demo's rows and all) on `/docs/components`, 146 SVGs on `/docs/charts`.

`pnpm check` and `pnpm typecheck` pass. No registry, publisher, preset or `/r/*` files touched, so nothing to regenerate.

## Noted, not fixed

`/studio` pulls **70 preload chunks for 570 KB** — roughly twice any other page's chunk count for less total weight. That's a request-count problem rather than a byte problem, and wants its own task.
