### PR TITLE
fix(www): serve /home.md from one shared module

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -8,7 +8,7 @@
     "dev:clean": "rm -rf node_modules/.vite .cache && pnpm build:registry && vite dev",
     "build:registry": "tsx scripts/registry-build.ts",
     "build": "pnpm build:registry && NODE_OPTIONS='--max-old-space-size=8192' vite build && pnpm build:postprocess",
-    "build:postprocess": "node scripts/patch-vercel-config.mjs",
+    "build:postprocess": "tsx scripts/patch-vercel-config.ts",
     "preview": "vite preview",
     "perf:budget": "node scripts/perf-budget.mjs",
     "typecheck": "pnpm build:registry && tsc --noEmit",

--- a/www/scripts/patch-vercel-config.ts
+++ b/www/scripts/patch-vercel-config.ts
@@ -18,6 +18,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 
+import { homeMarkdown } from "../src/config/home-md"
+
 const CONFIG = ".vercel/output/config.json"
 const STATIC_HOME_MD = ".vercel/output/static/home.md"
 
@@ -30,34 +32,15 @@ if (!existsSync(CONFIG)) {
 
 // 1) Static markdown homepage. On Vercel this static file is what actually
 // serves for GET /home.md and the "/" Accept:text/markdown negotiation (it
-// shadows the src/routes/home[.]md.tsx route). Keep byte-identical to that
-// route's BODY.
-const HOME_MD = `# dotUI
-
-> Build your design system, not someone else's. Compose beautiful, accessible React components and export them as code you own.
-
-dotUI is a design system platform and component registry built on React Aria Components, Tailwind CSS 4, and TypeScript 5. Generate a UI library that looks like your product — not a preset — with the style editor, then consume it through the shadcn CLI, the registry endpoint, or AI tooling like v0.
-
-## Documentation
-
-- Introduction: https://dotui.org/docs
-- Installation: https://dotui.org/docs/installation
-- Components index (llms.txt): https://dotui.org/llms.txt
-- Full documentation, single file (llms-full.txt): https://dotui.org/llms-full.txt
-- Component registry API: GET https://dotui.org/r/{name}
-
-## Links
-
-- GitHub: https://github.com/mehdibha/dotUI
-- X (Twitter): https://x.com/mehdibha
-- Discord: https://discord.gg/DXpj5V2fU8
-`
-
+// shadows the src/routes/home[.]md.tsx route, which serves the same module).
 mkdirSync(dirname(STATIC_HOME_MD), { recursive: true })
-writeFileSync(STATIC_HOME_MD, HOME_MD)
+writeFileSync(STATIC_HOME_MD, homeMarkdown)
 
 // 2) + 3) Override content-type and inject the rewrite.
-const config = JSON.parse(readFileSync(CONFIG, "utf-8"))
+const config = JSON.parse(readFileSync(CONFIG, "utf-8")) as {
+  overrides?: Record<string, { contentType: string }>
+  routes?: { src?: string; dest?: string; has?: unknown; handle?: string }[]
+}
 
 config.overrides ??= {}
 config.overrides["home.md"] = { contentType: "text/markdown; charset=utf-8" }

--- a/www/src/config/home-md.ts
+++ b/www/src/config/home-md.ts
@@ -1,0 +1,25 @@
+import { siteConfig } from "./site"
+
+// Markdown view of the homepage for AI agents, served at /home.md. Single
+// source for both the src/routes/home[.]md.tsx route (node preset / local dev)
+// and the static file scripts/patch-vercel-config.ts emits on Vercel.
+export const homeMarkdown = `# dotUI
+
+> ${siteConfig.description}
+
+dotUI is a design system platform and component registry built on React Aria Components, Tailwind CSS 4, and TypeScript 5. Generate a UI library that looks like your product — not a preset — with the style editor, then consume it through the shadcn CLI, the registry endpoint, or AI tooling like v0.
+
+## Documentation
+
+- Introduction: ${siteConfig.url}/docs
+- Installation: ${siteConfig.url}/docs/installation
+- Components index (llms.txt): ${siteConfig.url}/llms.txt
+- Full documentation, single file (llms-full.txt): ${siteConfig.url}/llms-full.txt
+- Component registry API: GET ${siteConfig.url}/r/{name}
+
+## Links
+
+- GitHub: ${siteConfig.links.github}
+- X (Twitter): ${siteConfig.links.twitter}
+- Discord: ${siteConfig.links.discord}
+`

--- a/www/src/routes/home[.]md.tsx
+++ b/www/src/routes/home[.]md.tsx
@@ -1,42 +1,21 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-import { siteConfig } from "@/config/site"
+import { homeMarkdown } from "@/config/home-md"
 
 // Serves /home.md — a concise markdown view of the homepage for AI agents,
 // linked from the page <head> as <link rel="alternate" type="text/markdown">.
 //
 // NOTE: on Vercel this route is shadowed by a static /home.md written at build
-// time by scripts/patch-vercel-config.mjs (the filesystem layer serves it before
+// time by scripts/patch-vercel-config.ts (the filesystem layer serves it before
 // this function), which is also what the "/" + Accept:text/markdown negotiation
 // resolves to. This route is the live source only on the node preset / local
-// dev. Keep BODY below byte-identical to the HOME_MD literal in that script.
-
-const BODY = `# dotUI
-
-> ${siteConfig.description}
-
-dotUI is a design system platform and component registry built on React Aria Components, Tailwind CSS 4, and TypeScript 5. Generate a UI library that looks like your product — not a preset — with the style editor, then consume it through the shadcn CLI, the registry endpoint, or AI tooling like v0.
-
-## Documentation
-
-- Introduction: ${siteConfig.url}/docs
-- Installation: ${siteConfig.url}/docs/installation
-- Components index (llms.txt): ${siteConfig.url}/llms.txt
-- Full documentation, single file (llms-full.txt): ${siteConfig.url}/llms-full.txt
-- Component registry API: GET ${siteConfig.url}/r/{name}
-
-## Links
-
-- GitHub: ${siteConfig.links.github}
-- X (Twitter): ${siteConfig.links.twitter}
-- Discord: ${siteConfig.links.discord}
-`
+// dev. Both read the same body from src/config/home-md.ts.
 
 export const Route = createFileRoute("/home.md")({
   server: {
     handlers: {
       GET: () =>
-        new Response(BODY, {
+        new Response(homeMarkdown, {
           headers: { "Content-Type": "text/markdown; charset=utf-8" },
         }),
     },


### PR DESCRIPTION
Closes #433.

The \`/home.md\` route interpolated \`siteConfig\` while \`patch-vercel-config.mjs\` carried a hardcoded copy of the same markdown. The static file shadows the route on Vercel, so production kept serving the old tagline after \`siteConfig.description\` changed.

- Add \`src/config/home-md.ts\` exporting the body, built from \`siteConfig\`.
- The route and the postprocess script both import it.
- The script becomes \`patch-vercel-config.ts\` and runs under \`tsx\` (like \`build:registry\` and the other scripts), so it can import from \`src/\`. Behaviour is unchanged: still a no-op when \`.vercel/output/config.json\` is absent.

Verified by running the script against a stub \`.vercel/output\` (writes the current description, injects the rewrite and content-type override) and without one (skips). \`pnpm check\` and \`pnpm typecheck\` pass.