### PR TITLE
feat(studio): add a create row to the preset picker

### DIFF
--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -191,10 +191,11 @@ function PresetSelector() {
       selectedId={selected}
       onPick={(item) => presetStore.set(item.id)}
       previewMode={previewMode}
+      withPreview
       sections={[
         {
           id: "yours",
-          title: "Yours",
+          title: "My systems",
           items: [
             {
               id: YOURS,
@@ -204,8 +205,8 @@ function PresetSelector() {
           ],
         },
         {
-          id: "built-in",
-          title: "Presets",
+          id: "featured",
+          title: "Featured",
           items: PRESETS.map((preset) => ({
             id: preset.id,
             name: preset.name,

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -9,6 +9,7 @@ import { useFilter } from "react-aria-components/Autocomplete"
 import { DesignSystemProvider } from "@/lib/styles"
 import { Responsive } from "@/registry/lib/responsive"
 import { cn } from "@/registry/lib/utils"
+import { Button } from "@/registry/ui/button"
 import {
   Command,
   CommandContent,
@@ -36,8 +37,6 @@ interface PresetPickerSection {
   id: string
   title: string
   items: PresetPickerItem[]
-  /** Ends the section with a "New design system" row; the section shows even when empty. */
-  onCreate?: () => void
 }
 
 interface PresetPickerProps {
@@ -59,6 +58,8 @@ interface PresetPickerProps {
   withPreview?: boolean
   /** Trailing controls on a row (e.g. a saved preset's actions menu). */
   renderItemActions?: (item: PresetPickerItem) => ReactNode
+  /** Adds a "+ New" button beside the search field; pressing it closes the picker first. */
+  onCreate?: () => void
 }
 
 /**
@@ -83,6 +84,7 @@ export function PresetPicker({
   previewMode,
   withPreview = false,
   renderItemActions,
+  onCreate,
 }: PresetPickerProps) {
   const content = (surface: "popover" | "drawer") => (
     <DialogContent
@@ -103,6 +105,7 @@ export function PresetPicker({
           previewMode={previewMode}
           withPreview={withPreview}
           renderItemActions={renderItemActions}
+          onCreate={onCreate}
         />
       )}
     </DialogContent>
@@ -137,6 +140,7 @@ function PresetPickerContent({
   previewMode,
   withPreview,
   renderItemActions,
+  onCreate,
 }: {
   sections: PresetPickerSection[]
   selectedId?: string
@@ -146,6 +150,7 @@ function PresetPickerContent({
   previewMode?: "light" | "dark"
   withPreview: boolean
   renderItemActions?: (item: PresetPickerItem) => ReactNode
+  onCreate?: () => void
 }) {
   // Autocomplete owns the filtering; we mirror the query only to keep the
   // section counts honest and to drop a section whose matches all filtered out
@@ -209,9 +214,6 @@ function PresetPickerContent({
     }, 150)
   }, [])
 
-  // A section's create row filters like a row of its own, and keeps the
-  // section on screen when it has nothing else to show.
-  const createMatches = !query || contains(CREATE_LABEL, query)
   const visible = sections
     .map((section) => ({
       ...section,
@@ -219,24 +221,13 @@ function PresetPickerContent({
         ? section.items.filter((item) => contains(item.name, query))
         : section.items,
     }))
-    .filter(
-      (section) =>
-        section.items.length > 0 || (section.onCreate && createMatches),
-    )
+    .filter((section) => section.items.length > 0)
   const allItems = sections.flatMap((section) => section.items)
   const previewItem =
     allItems.find((item) => item.id === previewId) ?? allItems[0]
   const flyout = surface === "popover" && withPreview
 
   function pick(key: Key) {
-    const create = sections.find(
-      (section) => createKey(section.id) === key,
-    )?.onCreate
-    if (create) {
-      close()
-      create()
-      return
-    }
     const item = allItems.find((candidate) => candidate.id === key)
     if (!item) return
     onPick(item)
@@ -245,26 +236,45 @@ function PresetPickerContent({
 
   const list = (
     <>
-      <SearchField
-        // No search autofocus on mobile — the keyboard would cover the list.
-        autoFocus={surface === "popover"}
-        aria-label="Search design systems"
-      >
-        <InputGroup>
-          <InputGroupAddon>
-            <SearchIcon />
-          </InputGroupAddon>
-          <Input
-            placeholder="Search design systems..."
-            onInput={(e) => {
-              setQuery(e.currentTarget.value)
-              // Typing moves the highlight to the first match, so from here on
-              // the pane follows it.
-              navigatedRef.current = true
+      {/* The Command styles give the search field its hairline; with a New
+          button beside it the row carries the line instead. */}
+      <div className={cn("flex items-center", onCreate && "border-b")}>
+        <SearchField
+          // No search autofocus on mobile — the keyboard would cover the list.
+          autoFocus={surface === "popover"}
+          aria-label="Search design systems"
+          className={cn(onCreate && "flex-1 border-b-0!")}
+        >
+          <InputGroup>
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+            <Input
+              placeholder="Search..."
+              onInput={(e) => {
+                setQuery(e.currentTarget.value)
+                // Typing moves the highlight to the first match, so from here on
+                // the pane follows it.
+                navigatedRef.current = true
+              }}
+            />
+          </InputGroup>
+        </SearchField>
+        {onCreate && (
+          <Button
+            variant="secondary"
+            size="md"
+            className="mt-2 mr-2 shrink-0"
+            onPress={() => {
+              close()
+              onCreate()
             }}
-          />
-        </InputGroup>
-      </SearchField>
+          >
+            <PlusIcon />
+            New
+          </Button>
+        )}
+      </div>
       <CommandContent
         aria-label="Design systems"
         onAction={pick}
@@ -319,19 +329,6 @@ function PresetPickerContent({
                 )}
               </CommandItem>
             ))}
-            {section.onCreate &&
-              createMatches && (
-                // A dashed slot at the end of the section: reads as "add one
-                // here", and stays a real row so arrow keys reach it.
-                <CommandItem
-                  id={createKey(section.id)}
-                  textValue={CREATE_LABEL}
-                  className="mt-0.5 justify-center border border-dashed border-border-control"
-                >
-                  <PlusIcon />
-                  {CREATE_LABEL}
-                </CommandItem>
-              )}
           </CommandSection>
         ))}
       </CommandContent>
@@ -360,9 +357,6 @@ function PresetPickerContent({
     </>
   )
 }
-
-const CREATE_LABEL = "New design system"
-const createKey = (sectionId: string) => `${sectionId}:create`
 
 /**
  * One option: the preset's accent as a dot and its name. The scope only themes

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -240,7 +240,10 @@ function PresetPickerContent({
           button beside it the row carries the line instead, inset to the
           input's edges like the rows below. */}
       <div
-        className={cn("flex items-center", onCreate && "mx-2 gap-2 border-b")}
+        className={cn(
+          "flex items-center",
+          onCreate && "mx-2 gap-2 border-b pb-2",
+        )}
       >
         <SearchField
           // No search autofocus on mobile — the keyboard would cover the list.

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { ReactNode } from "react"
-import { CheckIcon, SearchIcon } from "lucide-react"
+import { CheckIcon, PlusIcon, SearchIcon } from "lucide-react"
 import type { Key } from "react-aria-components"
 import { useFilter } from "react-aria-components/Autocomplete"
 
@@ -36,6 +36,8 @@ interface PresetPickerSection {
   id: string
   title: string
   items: PresetPickerItem[]
+  /** Ends the section with a "New design system" row; the section shows even when empty. */
+  onCreate?: () => void
 }
 
 interface PresetPickerProps {
@@ -84,7 +86,7 @@ export function PresetPicker({
 }: PresetPickerProps) {
   const content = (surface: "popover" | "drawer") => (
     <DialogContent
-      aria-label="Presets"
+      aria-label="Design systems"
       // `max-h-[inherit]` chains the popover's computed max-height (set inline
       // by react-aria from the available space) down to the list, so the
       // search field stays pinned and the list owns all the overflow — the
@@ -207,6 +209,9 @@ function PresetPickerContent({
     }, 150)
   }, [])
 
+  // A section's create row filters like a row of its own, and keeps the
+  // section on screen when it has nothing else to show.
+  const createMatches = !query || contains(CREATE_LABEL, query)
   const visible = sections
     .map((section) => ({
       ...section,
@@ -214,13 +219,24 @@ function PresetPickerContent({
         ? section.items.filter((item) => contains(item.name, query))
         : section.items,
     }))
-    .filter((section) => section.items.length > 0)
+    .filter(
+      (section) =>
+        section.items.length > 0 || (section.onCreate && createMatches),
+    )
   const allItems = sections.flatMap((section) => section.items)
   const previewItem =
     allItems.find((item) => item.id === previewId) ?? allItems[0]
   const flyout = surface === "popover" && withPreview
 
   function pick(key: Key) {
+    const create = sections.find(
+      (section) => createKey(section.id) === key,
+    )?.onCreate
+    if (create) {
+      close()
+      create()
+      return
+    }
     const item = allItems.find((candidate) => candidate.id === key)
     if (!item) return
     onPick(item)
@@ -303,6 +319,19 @@ function PresetPickerContent({
                 )}
               </CommandItem>
             ))}
+            {section.onCreate &&
+              createMatches && (
+                // A dashed slot at the end of the section: reads as "add one
+                // here", and stays a real row so arrow keys reach it.
+                <CommandItem
+                  id={createKey(section.id)}
+                  textValue={CREATE_LABEL}
+                  className="mt-0.5 justify-center border border-dashed border-border-control"
+                >
+                  <PlusIcon />
+                  {CREATE_LABEL}
+                </CommandItem>
+              )}
           </CommandSection>
         ))}
       </CommandContent>
@@ -331,6 +360,9 @@ function PresetPickerContent({
     </>
   )
 }
+
+const CREATE_LABEL = "New design system"
+const createKey = (sectionId: string) => `${sectionId}:create`
 
 /**
  * One option: the preset's accent as a dot and its name. The scope only themes

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -50,8 +50,6 @@ interface PresetPickerProps {
   onOpenChange?: (open: boolean) => void
   /** Desktop popover placement. */
   placement?: PopoverProps["placement"]
-  /** Extra classes on the desktop popover (e.g. the panel's instant motion). */
-  popoverClassName?: string
   /** Pin the previews to one mode (docs previews pin light/dark). */
   previewMode?: "light" | "dark"
   /** Show the hover flyout beside the popover on desktop. Off by default. */
@@ -80,7 +78,6 @@ export function PresetPicker({
   isOpen,
   onOpenChange,
   placement = "bottom start",
-  popoverClassName,
   previewMode,
   withPreview = false,
   renderItemActions,
@@ -121,7 +118,11 @@ export function PresetPicker({
           ) : (
             // The popover always sizes to the list column — the preview, when
             // on, floats outside it as a detached flyout.
-            <Popover placement={placement} className={popoverClassName}>
+            // Instant, like the panel chrome it belongs to.
+            <Popover
+              placement={placement}
+              className="transition-none will-change-auto"
+            >
               {content("popover")}
             </Popover>
           )
@@ -236,21 +237,21 @@ function PresetPickerContent({
 
   const list = (
     <>
-      {/* With a New button beside it the search field gives up its own
-          hairline; the row sits on the same inset as the rows below. */}
-      <div className={cn("flex items-center", onCreate && "mx-2 gap-2")}>
+      {/* The search row drops the Command's hairline and sits on the same
+          inset as the rows below; the New button, when any, shares it. */}
+      <div className="mx-2 flex items-center gap-2">
         <SearchField
           // No search autofocus on mobile — the keyboard would cover the list.
           autoFocus={surface === "popover"}
           aria-label="Search design systems"
-          className={cn(onCreate && "flex-1 border-b-0! px-0!")}
+          className="flex-1 border-b-0! px-0!"
         >
           <InputGroup>
             <InputGroupAddon>
               <SearchIcon />
             </InputGroupAddon>
             <Input
-              placeholder="Search design systems..."
+              placeholder="Search systems..."
               onInput={(e) => {
                 setQuery(e.currentTarget.value)
                 // Typing moves the highlight to the first match, so from here on
@@ -286,7 +287,7 @@ function PresetPickerContent({
         style={{
           // Relative so the rows' offsetTop reads against the scroller.
           position: "relative",
-          maxHeight: surface === "popover" ? 420 : "60vh",
+          maxHeight: surface === "popover" ? 320 : "60vh",
           // Shrink below the content when the inherited max-height is tighter
           // than the 420 cap.
           minHeight: 0,
@@ -340,7 +341,7 @@ function PresetPickerContent({
   return (
     <>
       <Command
-        className="max-h-[inherit] w-80 overflow-hidden"
+        className="max-h-[inherit] w-65 overflow-hidden"
         onKeyDownCapture={(e) => {
           if (e.key.startsWith("Arrow")) navigatedRef.current = true
         }}

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -236,15 +236,9 @@ function PresetPickerContent({
 
   const list = (
     <>
-      {/* The Command styles give the search field its hairline; with a New
-          button beside it the row carries the line instead, inset to the
-          input's edges like the rows below. */}
-      <div
-        className={cn(
-          "flex items-center",
-          onCreate && "mx-2 gap-2 border-b pb-2",
-        )}
-      >
+      {/* With a New button beside it the search field gives up its own
+          hairline; the row sits on the same inset as the rows below. */}
+      <div className={cn("flex items-center", onCreate && "mx-2 gap-2")}>
         <SearchField
           // No search autofocus on mobile — the keyboard would cover the list.
           autoFocus={surface === "popover"}

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -250,7 +250,7 @@ function PresetPickerContent({
               <SearchIcon />
             </InputGroupAddon>
             <Input
-              placeholder="Search..."
+              placeholder="Search design systems..."
               onInput={(e) => {
                 setQuery(e.currentTarget.value)
                 // Typing moves the highlight to the first match, so from here on
@@ -340,7 +340,7 @@ function PresetPickerContent({
   return (
     <>
       <Command
-        className="max-h-[inherit] w-[260px] overflow-hidden"
+        className="max-h-[inherit] w-80 overflow-hidden"
         onKeyDownCapture={(e) => {
           if (e.key.startsWith("Arrow")) navigatedRef.current = true
         }}
@@ -443,10 +443,10 @@ function PresetOptionRow({
  * aligned with it and sized to its content, drawn entirely on the previewed
  * preset's own surface. The body is the landing showcase's Controls card — the
  * same sampler the marketing grid opens with — so the preview and the landing
- * agree on what a design system looks like. It opens once (after the hover
+ * agree on what a design system looks like. It shows once (after the hover
  * delay upstream) and then never moves; swapping presets swaps its content
- * outright — the highlight moves tens of times per open, and animating the
- * swap would only slow it down.
+ * outright — the highlight moves tens of times per open, and animating any
+ * of it would only slow it down.
  */
 function PresetPreviewFlyout({
   item,
@@ -477,10 +477,8 @@ function PresetPreviewFlyout({
           // The Controls card *is* the surface: the shell borrows its bg and
           // sizes to it, so the flyout may run taller than the popover.
           "pointer-events-none absolute top-0 left-full ml-3 flex w-[340px] flex-col overflow-hidden rounded-xl border bg-card shadow-lg",
-          "origin-left transition-[opacity,transform,scale] ease-out will-change-[transform,opacity] motion-reduce:transition-none",
-          isVisible
-            ? "scale-100 opacity-100 duration-200"
-            : "-translate-x-1 scale-97 opacity-0 duration-150",
+          // Instant, like the rest of the panel chrome.
+          !isVisible && "hidden",
         )}
       >
         <div className="flex shrink-0 items-center gap-3 border-b p-3.5">

--- a/www/src/modules/presets/preset-picker.tsx
+++ b/www/src/modules/presets/preset-picker.tsx
@@ -237,13 +237,16 @@ function PresetPickerContent({
   const list = (
     <>
       {/* The Command styles give the search field its hairline; with a New
-          button beside it the row carries the line instead. */}
-      <div className={cn("flex items-center", onCreate && "border-b")}>
+          button beside it the row carries the line instead, inset to the
+          input's edges like the rows below. */}
+      <div
+        className={cn("flex items-center", onCreate && "mx-2 gap-2 border-b")}
+      >
         <SearchField
           // No search autofocus on mobile — the keyboard would cover the list.
           autoFocus={surface === "popover"}
           aria-label="Search design systems"
-          className={cn(onCreate && "flex-1 border-b-0!")}
+          className={cn(onCreate && "flex-1 border-b-0! px-0!")}
         >
           <InputGroup>
             <InputGroupAddon>
@@ -264,7 +267,7 @@ function PresetPickerContent({
           <Button
             variant="secondary"
             size="md"
-            className="mt-2 mr-2 shrink-0"
+            className="mt-2 shrink-0"
             onPress={() => {
               close()
               onCreate()
@@ -340,7 +343,7 @@ function PresetPickerContent({
   return (
     <>
       <Command
-        className="max-h-[inherit] w-[200px] overflow-hidden"
+        className="max-h-[inherit] w-[260px] overflow-hidden"
         onKeyDownCapture={(e) => {
           if (e.key.startsWith("Arrow")) navigatedRef.current = true
         }}

--- a/www/src/modules/studio/create-preset-dialog.tsx
+++ b/www/src/modules/studio/create-preset-dialog.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import { useState } from "react"
+import type { Key } from "react-aria-components"
+
+import { Button } from "@/registry/ui/button"
+import {
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/registry/ui/dialog"
+import { Label } from "@/registry/ui/field"
+import { Input } from "@/registry/ui/input"
+import { Modal } from "@/registry/ui/modal"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSection,
+  SelectSectionHeader,
+  SelectTrigger,
+} from "@/registry/ui/select"
+import { TextField } from "@/registry/ui/text-field"
+import { PRESETS } from "@/modules/presets/presets-data"
+import { encodeState } from "@/modules/studio/preset"
+import type { SavedPreset } from "@/modules/studio/preset"
+
+/**
+ * Creates a new saved design system from a name and a starting point — a
+ * built-in preset or one of the user's systems — then hands the snapshot back
+ * to the panel to store and apply.
+ */
+/** "Start from" entry for the working state when it matches no preset. */
+const CURRENT = "__current"
+
+export function CreatePresetDialog({
+  isOpen,
+  onOpenChange,
+  presets,
+  activeId,
+  currentState,
+  onCreate,
+}: {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  presets: SavedPreset[]
+  /** The active saved preset, if any. */
+  activeId?: string
+  /** The working state, encoded. */
+  currentState: string
+  onCreate: (name: string, state: string) => void
+}) {
+  // Start from what's on screen: the active saved preset, else the built-in
+  // the state matches, else the unsaved working state itself.
+  const initialBase =
+    (activeId && presets.some((p) => p.id === activeId) && activeId) ||
+    PRESETS.find((p) => (encodeState(p.state) ?? "") === currentState)?.id ||
+    CURRENT
+  const [name, setName] = useState("")
+  const [base, setBase] = useState<Key>(initialBase)
+  // Fields reset on every open (the modal stays mounted between opens).
+  const [wasOpen, setWasOpen] = useState(isOpen)
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen)
+    if (isOpen) {
+      setName("")
+      setBase(initialBase)
+    }
+  }
+
+  const trimmed = name.trim()
+
+  function submit() {
+    if (!trimmed) return
+    const saved = presets.find((p) => p.id === base)
+    const builtIn = PRESETS.find((p) => p.id === base)
+    const state =
+      base === CURRENT
+        ? currentState
+        : (saved?.state ?? (builtIn && encodeState(builtIn.state)) ?? "")
+    onCreate(trimmed, state)
+    onOpenChange(false)
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      className="w-full sm:max-w-sm"
+    >
+      <DialogContent
+        aria-label="New design system"
+        className="flex flex-col gap-4"
+      >
+        <div className="flex flex-col gap-1">
+          <DialogTitle className="text-base font-semibold">
+            New design system
+          </DialogTitle>
+          <DialogDescription className="text-sm text-fg-muted">
+            Name it and pick what to start from. You can change everything
+            after.
+          </DialogDescription>
+        </div>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault()
+            submit()
+          }}
+        >
+          <TextField
+            autoFocus
+            aria-label="Name"
+            value={name}
+            onChange={setName}
+          >
+            <Label>Name</Label>
+            <Input placeholder="My design system" />
+          </TextField>
+          <Select
+            aria-label="Start from"
+            selectedKey={base}
+            onSelectionChange={(key) => {
+              if (key != null) setBase(key)
+            }}
+          >
+            <Label>Start from</Label>
+            <SelectTrigger className="w-full" />
+            <SelectContent>
+              {initialBase === CURRENT && (
+                <SelectItem id={CURRENT}>Current changes</SelectItem>
+              )}
+              <SelectSection>
+                <SelectSectionHeader>Featured</SelectSectionHeader>
+                {PRESETS.map((p) => (
+                  <SelectItem key={p.id} id={p.id}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectSection>
+              {presets.length > 0 && (
+                <SelectSection>
+                  <SelectSectionHeader>My systems</SelectSectionHeader>
+                  {presets.map((p) => (
+                    <SelectItem key={p.id} id={p.id}>
+                      {p.name}
+                    </SelectItem>
+                  ))}
+                </SelectSection>
+              )}
+            </SelectContent>
+          </Select>
+        </form>
+        <div className="flex justify-end gap-2">
+          <Button size="sm" onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            variant="primary"
+            onPress={submit}
+            isDisabled={!trimmed}
+          >
+            Create
+          </Button>
+        </div>
+      </DialogContent>
+    </Modal>
+  )
+}

--- a/www/src/modules/studio/create-preset-dialog.tsx
+++ b/www/src/modules/studio/create-preset-dialog.tsx
@@ -30,7 +30,7 @@ import type { SavedPreset } from "@/modules/studio/preset"
  * built-in preset or one of the user's systems — then hands the snapshot back
  * to the panel to store and apply.
  */
-/** "Start from" entry for the working state when it matches no preset. */
+/** "Based on" entry for the working state when it matches no preset. */
 const CURRENT = "__current"
 
 export function CreatePresetDialog({
@@ -44,14 +44,14 @@ export function CreatePresetDialog({
   isOpen: boolean
   onOpenChange: (open: boolean) => void
   presets: SavedPreset[]
-  /** The active saved preset, if any. */
+  /** The active saved preset, when the working state still matches it. */
   activeId?: string
   /** The working state, encoded. */
   currentState: string
   onCreate: (name: string, state: string) => void
 }) {
-  // Start from what's on screen: the active saved preset, else the built-in
-  // the state matches, else the unsaved working state itself.
+  // Based on what's on screen: the active saved preset (when unedited), else
+  // the built-in the state matches, else the unsaved working state itself.
   const initialBase =
     (activeId && presets.some((p) => p.id === activeId) && activeId) ||
     PRESETS.find((p) => (encodeState(p.state) ?? "") === currentState)?.id ||
@@ -97,8 +97,7 @@ export function CreatePresetDialog({
             New design system
           </DialogTitle>
           <DialogDescription className="text-sm text-fg-muted">
-            Name it and pick what to start from. You can change everything
-            after.
+            Give it a name and a starting point. Everything stays editable.
           </DialogDescription>
         </div>
         <form
@@ -118,13 +117,13 @@ export function CreatePresetDialog({
             <Input placeholder="My design system" />
           </TextField>
           <Select
-            aria-label="Start from"
+            aria-label="Based on"
             selectedKey={base}
             onSelectionChange={(key) => {
               if (key != null) setBase(key)
             }}
           >
-            <Label>Start from</Label>
+            <Label>Based on</Label>
             <SelectTrigger className="w-full" />
             <SelectContent>
               {initialBase === CURRENT && (

--- a/www/src/modules/studio/create-preset-dialog.tsx
+++ b/www/src/modules/studio/create-preset-dialog.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState } from "react"
-import type { Key } from "react-aria-components"
 
 import { Button } from "@/registry/ui/button"
 import {
@@ -12,73 +11,34 @@ import {
 import { Label } from "@/registry/ui/field"
 import { Input } from "@/registry/ui/input"
 import { Modal } from "@/registry/ui/modal"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectSection,
-  SelectSectionHeader,
-  SelectTrigger,
-} from "@/registry/ui/select"
 import { TextField } from "@/registry/ui/text-field"
-import { PRESETS } from "@/modules/presets/presets-data"
-import { encodeState } from "@/modules/studio/preset"
-import type { SavedPreset } from "@/modules/studio/preset"
 
 /**
- * Creates a new saved design system from a name and a starting point — a
- * built-in preset or one of the user's systems — then hands the snapshot back
- * to the panel to store and apply.
+ * Names a new design system. It starts from Origin — a blank canvas; forking
+ * a featured or saved system is pick it, edit, Save as new.
  */
-/** "Based on" entry for the working state when it matches no preset. */
-const CURRENT = "__current"
-
 export function CreatePresetDialog({
   isOpen,
   onOpenChange,
-  presets,
-  activeId,
-  currentState,
   onCreate,
 }: {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
-  presets: SavedPreset[]
-  /** The active saved preset, when the working state still matches it. */
-  activeId?: string
-  /** The working state, encoded. */
-  currentState: string
-  onCreate: (name: string, state: string) => void
+  onCreate: (name: string) => void
 }) {
-  // Based on what's on screen: the active saved preset (when unedited), else
-  // the built-in the state matches, else the unsaved working state itself.
-  const initialBase =
-    (activeId && presets.some((p) => p.id === activeId) && activeId) ||
-    PRESETS.find((p) => (encodeState(p.state) ?? "") === currentState)?.id ||
-    CURRENT
   const [name, setName] = useState("")
-  const [base, setBase] = useState<Key>(initialBase)
-  // Fields reset on every open (the modal stays mounted between opens).
+  // The field resets on every open (the modal stays mounted between opens).
   const [wasOpen, setWasOpen] = useState(isOpen)
   if (isOpen !== wasOpen) {
     setWasOpen(isOpen)
-    if (isOpen) {
-      setName("")
-      setBase(initialBase)
-    }
+    if (isOpen) setName("")
   }
 
   const trimmed = name.trim()
 
   function submit() {
     if (!trimmed) return
-    const saved = presets.find((p) => p.id === base)
-    const builtIn = PRESETS.find((p) => p.id === base)
-    const state =
-      base === CURRENT
-        ? currentState
-        : (saved?.state ?? (builtIn && encodeState(builtIn.state)) ?? "")
-    onCreate(trimmed, state)
+    onCreate(trimmed)
     onOpenChange(false)
   }
 
@@ -97,11 +57,11 @@ export function CreatePresetDialog({
             New design system
           </DialogTitle>
           <DialogDescription className="text-sm text-fg-muted">
-            Give it a name and a starting point. Everything stays editable.
+            Starts from Origin, the default look. Every decision is yours from
+            there.
           </DialogDescription>
         </div>
         <form
-          className="flex flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault()
             submit()
@@ -116,39 +76,6 @@ export function CreatePresetDialog({
             <Label>Name</Label>
             <Input placeholder="My design system" />
           </TextField>
-          <Select
-            aria-label="Based on"
-            selectedKey={base}
-            onSelectionChange={(key) => {
-              if (key != null) setBase(key)
-            }}
-          >
-            <Label>Based on</Label>
-            <SelectTrigger className="w-full" />
-            <SelectContent>
-              {initialBase === CURRENT && (
-                <SelectItem id={CURRENT}>Current changes</SelectItem>
-              )}
-              <SelectSection>
-                <SelectSectionHeader>Featured</SelectSectionHeader>
-                {PRESETS.map((p) => (
-                  <SelectItem key={p.id} id={p.id}>
-                    {p.name}
-                  </SelectItem>
-                ))}
-              </SelectSection>
-              {presets.length > 0 && (
-                <SelectSection>
-                  <SelectSectionHeader>My systems</SelectSectionHeader>
-                  {presets.map((p) => (
-                    <SelectItem key={p.id} id={p.id}>
-                      {p.name}
-                    </SelectItem>
-                  ))}
-                </SelectSection>
-              )}
-            </SelectContent>
-          </Select>
         </form>
         <div className="flex justify-end gap-2">
           <Button size="sm" onPress={() => onOpenChange(false)}>

--- a/www/src/modules/studio/create.tsx
+++ b/www/src/modules/studio/create.tsx
@@ -12,6 +12,7 @@ import { getRouteApi } from "@tanstack/react-router"
 import { cn } from "@/registry/lib/utils"
 import { PresetPicker } from "@/modules/presets/preset-picker"
 import { ORIGIN, PRESETS } from "@/modules/presets/presets-data"
+import { CreatePresetDialog } from "@/modules/studio/create-preset-dialog"
 import { ExportDialog } from "@/modules/studio/export"
 import {
   decodePreset,
@@ -63,8 +64,9 @@ export function StudioPanel({ className }: { className?: string }) {
   } = useMyPresets()
   const storedName = useDesignSystemName()
   const [saveOpen, setSaveOpen] = useState(false)
-  // Preset pick held back by the unsaved-changes guard, awaiting save/discard.
-  const [pendingPick, setPendingPick] = useState<string | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+  // A pick or create held back by the unsaved-changes guard, awaiting save/discard.
+  const [pending, setPending] = useState<(() => void) | null>(null)
 
   // The header names what's being edited: the active saved system (dotted when
   // edited past its snapshot), else the standalone design-system name.
@@ -83,27 +85,30 @@ export function StudioPanel({ className }: { className?: string }) {
     : currentState !== "" && !builtInStates.has(currentState)
 
   // Saved systems decode to full design systems for the picker's mini previews.
-  const pickerSections = useMemo(() => {
-    const mine = {
-      id: "mine",
-      title: "My systems",
-      items: presets.map((saved) => ({
-        id: saved.id,
-        name: saved.name,
-        designSystem: resolveDesignSystem(decodePreset(saved.state).state),
-      })),
-    }
-    const builtIn = {
-      id: "built-in",
-      title: "Presets",
-      items: PRESETS.map((p) => ({
-        id: p.id,
-        name: p.name,
-        designSystem: p.designSystem,
-      })),
-    }
-    return presets.length > 0 ? [mine, builtIn] : [builtIn]
-  }, [presets])
+  const pickerSections = useMemo(
+    () => [
+      {
+        id: "mine",
+        title: "My systems",
+        items: presets.map((saved) => ({
+          id: saved.id,
+          name: saved.name,
+          designSystem: resolveDesignSystem(decodePreset(saved.state).state),
+        })),
+        onCreate: () => setCreateOpen(true),
+      },
+      {
+        id: "featured",
+        title: "Featured",
+        items: PRESETS.map((p) => ({
+          id: p.id,
+          name: p.name,
+          designSystem: p.designSystem,
+        })),
+      },
+    ],
+    [presets],
+  )
 
   // Apply a state and close the gallery in one navigation — two separate
   // navigates would race each other's search updates.
@@ -140,19 +145,25 @@ export function StudioPanel({ className }: { className?: string }) {
     applyState(encodeState(builtIn.state))
   }
 
-  // Applying a preset over unsaved work asks first; over clean state it's instant.
-  function requestPick(itemId: string) {
-    if (isDirty) setPendingPick(itemId)
-    else pickPreset(itemId)
+  function createPreset(name: string, state: string) {
+    save(name, state)
+    saveDesignSystemName(name)
+    applyState(state)
   }
 
-  function resolvePendingPick(saveFirst: boolean) {
+  // Replacing the state over unsaved work asks first; over clean state it's instant.
+  function guarded(action: () => void) {
+    if (isDirty) setPending(() => action)
+    else action()
+  }
+
+  function resolvePending(saveFirst: boolean) {
     if (saveFirst) {
       if (activeSaved) update(activeSaved.id, currentState)
       else save(displayName, currentState)
     }
-    if (pendingPick) pickPreset(pendingPick)
-    setPendingPick(null)
+    pending?.()
+    setPending(null)
   }
 
   const system: PanelSystem = {
@@ -168,7 +179,7 @@ export function StudioPanel({ className }: { className?: string }) {
         popoverClassName={INSTANT_POPOVER}
         sections={pickerSections}
         selectedId={activeSaved && !isDirty ? activeSaved.id : undefined}
-        onPick={(item) => requestPick(item.id)}
+        onPick={(item) => guarded(() => pickPreset(item.id))}
         withPreview
         renderItemActions={(item) => {
           const saved = presets.find((p) => p.id === item.id)
@@ -198,13 +209,21 @@ export function StudioPanel({ className }: { className?: string }) {
     >
       <DrillInPanel chapters={CHAPTERS} studio={studio} system={system} />
       <SavePresetDialog isOpen={saveOpen} onOpenChange={setSaveOpen} />
+      <CreatePresetDialog
+        isOpen={createOpen}
+        onOpenChange={setCreateOpen}
+        presets={presets}
+        activeId={activeSaved?.id}
+        currentState={currentState}
+        onCreate={(name, state) => guarded(() => createPreset(name, state))}
+      />
       <UnsavedChangesDialog
-        isOpen={pendingPick !== null}
+        isOpen={pending !== null}
         onOpenChange={(open) => {
-          if (!open) setPendingPick(null)
+          if (!open) setPending(null)
         }}
-        onSave={() => resolvePendingPick(true)}
-        onDiscard={() => resolvePendingPick(false)}
+        onSave={() => resolvePending(true)}
+        onDiscard={() => resolvePending(false)}
       />
     </div>
   )

--- a/www/src/modules/studio/create.tsx
+++ b/www/src/modules/studio/create.tsx
@@ -210,16 +210,7 @@ export function StudioPanel({ className }: { className?: string }) {
       <CreatePresetDialog
         isOpen={createOpen}
         onOpenChange={setCreateOpen}
-        presets={presets}
-        activeId={isDirty ? undefined : activeSaved?.id}
-        currentState={currentState}
-        // Creating from the working state keeps the unsaved edits — only a
-        // different base would throw them away.
-        onCreate={(name, state) =>
-          state === currentState
-            ? createPreset(name, state)
-            : guarded(() => createPreset(name, state))
-        }
+        onCreate={(name) => guarded(() => createPreset(name, ORIGIN_CANON))}
       />
       <UnsavedChangesDialog
         isOpen={pending !== null}

--- a/www/src/modules/studio/create.tsx
+++ b/www/src/modules/studio/create.tsx
@@ -31,7 +31,6 @@ import { UnsavedChangesDialog } from "@/modules/studio/unsaved-changes-dialog"
 import { DrillInPanel } from "./drill-in"
 import type { PanelSystem } from "./panel"
 import { resolveDesignSystem } from "./resolve"
-import { INSTANT_POPOVER } from "./rows"
 import { CHAPTERS } from "./state"
 import { useStudio } from "./use-studio"
 
@@ -173,7 +172,6 @@ export function StudioPanel({ className }: { className?: string }) {
       <PresetPicker
         isOpen={gallery === true}
         onOpenChange={setGalleryOpen}
-        popoverClassName={INSTANT_POPOVER}
         sections={pickerSections}
         selectedId={activeSaved && !isDirty ? activeSaved.id : undefined}
         onPick={(item) => guarded(() => pickPreset(item.id))}

--- a/www/src/modules/studio/create.tsx
+++ b/www/src/modules/studio/create.tsx
@@ -85,30 +85,27 @@ export function StudioPanel({ className }: { className?: string }) {
     : currentState !== "" && !builtInStates.has(currentState)
 
   // Saved systems decode to full design systems for the picker's mini previews.
-  const pickerSections = useMemo(
-    () => [
-      {
-        id: "mine",
-        title: "My systems",
-        items: presets.map((saved) => ({
-          id: saved.id,
-          name: saved.name,
-          designSystem: resolveDesignSystem(decodePreset(saved.state).state),
-        })),
-        onCreate: () => setCreateOpen(true),
-      },
-      {
-        id: "featured",
-        title: "Featured",
-        items: PRESETS.map((p) => ({
-          id: p.id,
-          name: p.name,
-          designSystem: p.designSystem,
-        })),
-      },
-    ],
-    [presets],
-  )
+  const pickerSections = useMemo(() => {
+    const mine = {
+      id: "mine",
+      title: "My systems",
+      items: presets.map((saved) => ({
+        id: saved.id,
+        name: saved.name,
+        designSystem: resolveDesignSystem(decodePreset(saved.state).state),
+      })),
+    }
+    const featured = {
+      id: "featured",
+      title: "Featured",
+      items: PRESETS.map((p) => ({
+        id: p.id,
+        name: p.name,
+        designSystem: p.designSystem,
+      })),
+    }
+    return presets.length > 0 ? [mine, featured] : [featured]
+  }, [presets])
 
   // Apply a state and close the gallery in one navigation — two separate
   // navigates would race each other's search updates.
@@ -180,6 +177,7 @@ export function StudioPanel({ className }: { className?: string }) {
         sections={pickerSections}
         selectedId={activeSaved && !isDirty ? activeSaved.id : undefined}
         onPick={(item) => guarded(() => pickPreset(item.id))}
+        onCreate={() => setCreateOpen(true)}
         withPreview
         renderItemActions={(item) => {
           const saved = presets.find((p) => p.id === item.id)

--- a/www/src/modules/studio/create.tsx
+++ b/www/src/modules/studio/create.tsx
@@ -211,9 +211,15 @@ export function StudioPanel({ className }: { className?: string }) {
         isOpen={createOpen}
         onOpenChange={setCreateOpen}
         presets={presets}
-        activeId={activeSaved?.id}
+        activeId={isDirty ? undefined : activeSaved?.id}
         currentState={currentState}
-        onCreate={(name, state) => guarded(() => createPreset(name, state))}
+        // Creating from the working state keeps the unsaved edits — only a
+        // different base would throw them away.
+        onCreate={(name, state) =>
+          state === currentState
+            ? createPreset(name, state)
+            : guarded(() => createPreset(name, state))
+        }
       />
       <UnsavedChangesDialog
         isOpen={pending !== null}

--- a/www/src/modules/studio/save-preset-dialog.tsx
+++ b/www/src/modules/studio/save-preset-dialog.tsx
@@ -65,13 +65,16 @@ export function SavePresetDialog({
       onOpenChange={onOpenChange}
       className="w-full sm:max-w-sm"
     >
-      <DialogContent aria-label="Save preset" className="flex flex-col gap-4">
+      <DialogContent
+        aria-label="Save design system"
+        className="flex flex-col gap-4"
+      >
         <div className="flex flex-col gap-1">
           <DialogTitle className="text-base font-semibold">
-            Save preset
+            Save design system
           </DialogTitle>
           <DialogDescription className="text-sm text-fg-muted">
-            Store the current system as a named preset you can reapply later.
+            Store the current design system under a name you can come back to.
           </DialogDescription>
         </div>
         <form
@@ -84,7 +87,7 @@ export function SavePresetDialog({
         >
           <TextField
             autoFocus
-            aria-label="Preset name"
+            aria-label="Name"
             value={name}
             onChange={setName}
           >

--- a/www/src/modules/studio/saved-preset-actions.tsx
+++ b/www/src/modules/studio/saved-preset-actions.tsx
@@ -102,9 +102,12 @@ function RenamePresetDialog({
       }}
       className="w-full sm:max-w-sm"
     >
-      <DialogContent aria-label="Rename preset" className="flex flex-col gap-4">
+      <DialogContent
+        aria-label="Rename design system"
+        className="flex flex-col gap-4"
+      >
         <DialogTitle className="text-base font-semibold">
-          Rename preset
+          Rename design system
         </DialogTitle>
         <form
           onSubmit={(e) => {
@@ -114,7 +117,7 @@ function RenamePresetDialog({
         >
           <TextField
             autoFocus
-            aria-label="Preset name"
+            aria-label="Name"
             value={name}
             onChange={setName}
           >

--- a/www/src/modules/studio/unsaved-changes-dialog.tsx
+++ b/www/src/modules/studio/unsaved-changes-dialog.tsx
@@ -38,7 +38,7 @@ export function UnsavedChangesDialog({
             Unsaved changes
           </DialogTitle>
           <DialogDescription className="text-sm text-fg-muted">
-            Applying this preset will replace your unsaved changes.
+            Applying this design system will replace your unsaved changes.
           </DialogDescription>
         </div>
         <div className="flex justify-end gap-2">


### PR DESCRIPTION
## What

- The picker's search row gains a secondary **+ New** button beside the search field, sized to the input on a 320px surface. Pressing it closes the picker and opens the **New design system** modal.
- The modal asks for a **Name** only. A new design system starts from Origin, the default look; forking a featured or saved system is pick it, edit, Save as new.
- Creating saves the snapshot, makes it the active system, and applies it. Over unsaved work it goes through the existing unsaved-changes guard, generalized from "pending pick id" to a pending action.
- `PresetPicker` gains an optional `onCreate`; the docs toolbar picker doesn't pass it and is unchanged apart from the shared copy below. Its preview flyout now shows and hides instantly, like the rest of the panel chrome.

## Naming

Picker and dialogs settle on one noun, **design system**, for built-ins and user-made alike. Sections are **My systems** / **Featured**. "Save preset" / "Rename preset" become "Save design system" / "Rename design system", the search placeholder is "Search design systems...", and the unsaved-changes dialog says "design system". Code identifiers, URLs (`?preset=`) and storage keys keep `preset`.

## Reviewer notes

- The create dialog resets its field on open via a render-time state compare instead of an effect (the modal stays mounted between opens).
- Known, not in this PR: picking a built-in never shows the check mark, because the panel only maps saved ids to `selectedId`. One-line fix in `create.tsx`; happy to fold it in.
- Follow-up: the same vocabulary should sweep docs, llms.txt, home.md, the v0 emit text and the docs toolbar's "Yours" / "Presets" sections.

Verified in the browser: from Stripe, + New → "Blank" switches the header and applies Origin; it appears checked under My systems; Featured lists the 10 built-ins.