### PR TITLE
fix(www): fix home card column width below lg

### DIFF
--- a/www/src/components/showcase/cards-grid.tsx
+++ b/www/src/components/showcase/cards-grid.tsx
@@ -131,9 +131,11 @@ function CardColumn({
 }
 
 // The landing showcase grid: a rail, the AI banner over two card columns, and a
-// side column wherever four columns fit. Three equal columns, four at sm–lg
-// and xl. Memoized: the grid re-themes via context and CSS vars, so a parent
-// re-render (preset swap) never needs to re-render the cards themselves.
+// side column wherever four columns fit. Three columns, four at sm–lg and xl.
+// Below lg the columns are a fixed 18rem (the grid bleeds past the viewport
+// there); from lg they share the container width. Memoized: the grid
+// re-themes via context and CSS vars, so a parent re-render (preset swap)
+// never needs to re-render the cards themselves.
 export const CardsGrid = memo(function CardsGrid({
   className,
 }: {
@@ -142,7 +144,7 @@ export const CardsGrid = memo(function CardsGrid({
   return (
     <div
       className={cn(
-        "grid grid-cols-3 items-start gap-5 sm:grid-cols-4 lg:grid-cols-3 xl:grid-cols-4",
+        "grid grid-cols-[repeat(3,18rem)] items-start gap-5 sm:grid-cols-[repeat(4,18rem)] lg:grid-cols-3 xl:grid-cols-4",
         className,
       )}
     >

--- a/www/src/modules/marketing/cards.tsx
+++ b/www/src/modules/marketing/cards.tsx
@@ -56,7 +56,7 @@ export function Cards() {
             color={preset.color}
             icons={preset.icons}
           >
-            <CardsGrid className="relative z-20 w-[max(52rem,150vw)] max-w-none [zoom:0.8] [mask-image:linear-gradient(to_right,black_calc(125vw_-_1.25*var(--crop-pl)_-_1.25*var(--edge-fade)),transparent_calc(125vw_-_1.25*var(--crop-pl)))] [--edge-fade:2.5rem] lg:w-full lg:[zoom:1] lg:[mask-image:none]" />
+            <CardsGrid className="relative z-20 w-max [zoom:0.8] [mask-image:linear-gradient(to_right,black_calc(125vw_-_1.25*var(--crop-pl)_-_1.25*var(--edge-fade)),transparent_calc(125vw_-_1.25*var(--crop-pl)))] [--edge-fade:2.5rem] lg:w-full lg:[zoom:1] lg:[mask-image:none]" />
           </DesignSystemProvider>
         </div>
         <SkeletonRail side="right" />


### PR DESCRIPTION
## Summary

- Below `lg` the home showcase grid was `max(52rem, 150vw)` wide, so its columns were only fixed under ~554px and grew with the viewport above that.
- Columns are now a fixed `18rem` (`repeat(3, 18rem)`, `repeat(4, 18rem)` from `sm`) and the grid is `w-max`, so cards keep the same size at every width below 1024px.
- The 0.8 zoom, right-edge fade, crop padding, skeleton rails and the `lg`+ fluid layout are unchanged.

Verified at 375, 500, 768, 900 and 1000px: columns are 288px (230px visual) throughout, the grid still bleeds right with the fade, and there is no horizontal page scroll.