### PR TITLE
fix(www): refine hero tools copy and add beta eyebrow dot

### DIFF
--- a/www/src/modules/marketing/hero-stack.tsx
+++ b/www/src/modules/marketing/hero-stack.tsx
@@ -10,19 +10,19 @@ import { TailwindIcon } from "@/components/icons/tailwind"
 
 const tools = [
   {
-    prefix: "Built on",
+    prefix: "Powered by",
     name: "React Aria",
     href: "https://react-spectrum.adobe.com/react-aria",
     icon: <ReactAriaIcon className="size-5" />,
   },
   {
     prefix: "Styled with",
-    name: "Tailwind",
+    name: "Tailwind CSS",
     href: "https://tailwindcss.com",
     icon: <TailwindIcon className="size-8 text-[#38bdf8]" />,
   },
   {
-    prefix: "Installed via",
+    prefix: "Installed with",
     name: "shadcn CLI",
     href: "https://ui.shadcn.com",
     icon: <ShadcnIcon className="size-6" />,
@@ -34,7 +34,7 @@ type Tool = (typeof tools)[number]
 function Label({ tool }: { tool: Tool }) {
   return (
     <>
-      {tool.prefix} <span className="font-medium">{tool.name}</span>
+      {tool.prefix} <span className="font-semibold">{tool.name}</span>
     </>
   )
 }

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -9,6 +9,7 @@ import { HeroWordSwap } from "@/modules/marketing/hero-word-swap"
 function HeroEyebrow() {
   return (
     <Eyebrow className="mb-3 border-transparent bg-inverse/5">
+      <span className="size-1.5 rounded-full bg-fg-muted" />
       Currently in beta
     </Eyebrow>
   )


### PR DESCRIPTION
## Summary
- Hero tools strip: "Built on React Aria" → "Powered by React Aria", "Tailwind" → "Tailwind CSS", "Installed via shadcn CLI" → "Installed with shadcn CLI"; tool names bumped from `font-medium` to `font-semibold`.
- Beta eyebrow: add a small muted dot before "Currently in beta".

## Test plan
- [ ] Home hero renders the three tool labels with the new copy
- [ ] "Currently in beta" eyebrow shows the dot
- `pnpm check` passes on the changed files