### PR TITLE
docs: replace gallery mode toggle with a preset intro

### DIFF
--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -299,7 +299,7 @@ export function PreviewControls({ className }: { className?: string }) {
 export function PagePreviewControls() {
   return (
     <p className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-fg-muted">
-      You&apos;re looking at the
+      You&apos;re looking at
       <PresetSelector variant="secondary" />
       design system.
     </p>

--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -292,15 +292,16 @@ export function PreviewControls({ className }: { className?: string }) {
 }
 
 /**
- * The page-level toolbar of gallery pages (frontmatter `preview`): the preset
- * picker and mode toggle, right-aligned under the page header. Same store, so
- * it stays in sync with every per-demo toolbar.
+ * The intro on gallery pages (frontmatter `preview`): the preset picker sits
+ * in the sentence so it reads as copy, not a toolbar. Same store as every
+ * per-demo toolbar.
  */
 export function PagePreviewControls() {
   return (
-    <div className="flex items-center justify-end gap-3">
+    <p className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-fg-muted">
+      You&apos;re looking at the
       <PresetSelector variant="secondary" />
-      <PreviewModeToggle variant="secondary" />
-    </div>
+      design system.
+    </p>
   )
 }


### PR DESCRIPTION
## Summary
- Remove the light/dark switch from the Components and Chart examples galleries
- Put the preset picker in an intro sentence: “You’re looking at the [preset] design system.”
- Per-demo toolbars still have their own mode toggle

## Test plan
- [ ] Open `/docs/components` — no gallery mode toggle; intro sentence + picker sit below the header separator with the original spacing
- [ ] Open `/docs/charts` — same intro and picker, no mode toggle
- [ ] Switch presets from the gallery picker and confirm the cards restyle
- [ ] Open a component docs page (e.g. Button) and confirm the per-demo toolbar still has preset + light/dark


Made with [Cursor](https://cursor.com)